### PR TITLE
Remove extra `force: true`

### DIFF
--- a/lib/generators/chromeapp/all/templates/Gruntfile.js
+++ b/lib/generators/chromeapp/all/templates/Gruntfile.js
@@ -33,7 +33,6 @@ module.exports = function( grunt ) {
           images_dir: 'app/images',
           javascripts_dir: 'temp/scripts',
           force: true
-          force: true
         }
       }
     },


### PR DESCRIPTION
Removing extra force option that was causing a syntax error when trying to run the server after generating a chromeapp.
