### PR TITLE
Fix incorrect English in quickstart template.

### DIFF
--- a/lib/generators/quickstart/all/templates/app/index.html
+++ b/lib/generators/quickstart/all/templates/app/index.html
@@ -18,7 +18,7 @@
     <body>
     <div class="container">
         <div class="hero-unit">
-            <h1>Cheerio!</h1>
+            <h1>Wotcha!</h1>
             <p>You now have</p>
             <ul>
                 <li>HTML5 Boilerplate</li>


### PR DESCRIPTION
The quickstart generator appears to use "cheerio" as a synonym for
"hello" or "welcome". This is incorrect in the Southern English dialect
insomuch as "cheerio" means specifically "goodbye" or "so long".

I suggest changing this either explicitly to a more traditional "hello"
or "welcome" message or in the alternative using a more correct idiom
such as "wotcha", "hallo" or "hey nonny nonny".

[Credentials: I am a native English speaker.]
