### PR TITLE
fetch.js: fix typo 'a few moment' -> 'a few moments'

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -15,7 +15,7 @@ function fetch(tarball, target, cb) {
 
   var log = this.log
     .subhead('Fetching ' + tarball)
-    .writeln('This might take a few moment'.yellow);
+    .writeln('This might take a few moments'.yellow);
 
   // tarball untar opts
   var extractOpts = { type: 'Directory', path: target, strip: 1 };


### PR DESCRIPTION
Fix a typo in the install script which claims it will take "a few
moment" to complete. One might as well make a good impression while
installing :).
