### PR TITLE
Classify app's name.

### DIFF
--- a/lib/generators/ember/templates/app.js
+++ b/lib/generators/ember/templates/app.js
@@ -1,3 +1,3 @@
 
 
-var <%= grunt.util._.camelize(appname) %> = Ember.Application.create();
+var <%= grunt.util._.classify(appname) %> = Ember.Application.create();

--- a/lib/generators/ember/templates/array_controller.js
+++ b/lib/generators/ember/templates/array_controller.js
@@ -1,4 +1,4 @@
-<%= _.camelize(appname) %>.<%= _.classify(name) %>Controller = Ember.ArrayController.extend({
+<%= _.classify(appname) %>.<%= _.classify(name) %>Controller = Ember.ArrayController.extend({
   // Implement your controller here.
   //
   // An ArrayController has a `content` property, which you should

--- a/lib/generators/ember/templates/controller.js
+++ b/lib/generators/ember/templates/controller.js
@@ -1,4 +1,4 @@
-<%= _.camelize(appname) %>.<%= _.classify(name) %>Controller = Ember.ObjectController.extend({
+<%= _.classify(appname) %>.<%= _.classify(name) %>Controller = Ember.ObjectController.extend({
   // Implement your controller here.
 });
 

--- a/lib/generators/ember/templates/model.js
+++ b/lib/generators/ember/templates/model.js
@@ -1,5 +1,5 @@
 
 // Requires Ember-Data
-// <%= _.camelize(appname) %>.<%= _.classify(name) %> = DS.Model.extend({<% _.each(attrs, function(attr, i) { %>
+// <%= _.classify(appname) %>.<%= _.classify(name) %> = DS.Model.extend({<% _.each(attrs, function(attr, i) { %>
 //   <%= _.camelize(attr.name) %>: DS.attr('<%= attr.type %>')<% if(i < (attributes.length - 1)) { %>,<% } %>
 // <% }); %>});

--- a/lib/generators/ember/templates/router.js
+++ b/lib/generators/ember/templates/router.js
@@ -1,4 +1,4 @@
-<%= grunt.util._.camelize(appname) %>.Router = Ember.Router.extend({
+<%= grunt.util._.classify(appname) %>.Router = Ember.Router.extend({
   root: Ember.Route.extend({
     index: Ember.Route.extend({
       route: '/'

--- a/lib/generators/ember/templates/store.js
+++ b/lib/generators/ember/templates/store.js
@@ -1,5 +1,5 @@
 // Requires Ember-Data
-// <%= grunt.util._.camelize(appname) %>.Store = DS.Store.extend({
+// <%= grunt.util._.classify(appname) %>.Store = DS.Store.extend({
 //   revision: 4,
 //   adapter: DS.RESTAdapter.create()
 // });

--- a/lib/generators/ember/templates/view.js
+++ b/lib/generators/ember/templates/view.js
@@ -1,3 +1,3 @@
-<%= grunt.util._.camelize(appname) %>.<%= grunt.util._.classify(name) %>View = Ember.View.extend({
+<%= grunt.util._.classify(appname) %>.<%= grunt.util._.classify(name) %>View = Ember.View.extend({
   templateName: '<%= grunt.util._.underscored(name) %>'
 });


### PR DESCRIPTION
Ember requires that all namespaces are capitalized. Since Ember.Application
inherits from Ember.Namespace, the app's name should be capitalized as well.
