### PR TITLE
Fix Chrome App generator to not use the experimental namespace.

### DIFF
--- a/lib/generators/chromeapp/all/templates/app/main.js
+++ b/lib/generators/chromeapp/all/templates/app/main.js
@@ -4,7 +4,7 @@
  * @see http://developer.chrome.com/trunk/apps/experimental.app.html
  * @see http://developer.chrome.com/trunk/apps/app.window.html
  */
-chrome.app.runtime.onLaunched.addListener(function() {
+chrome.app.runtime.onLaunched.addListener(function(intentData) {
     chrome.app.window.create('index.html', {
         width: 500,
         height: 309


### PR DESCRIPTION
Removing the experimental namespace for Chrome Apps.  It is no longer need for any platform that works with Apps.
