### PR TITLE
Match application namespace

### DIFF
--- a/lib/generators/backbone/templates/collection.js
+++ b/lib/generators/backbone/templates/collection.js
@@ -1,4 +1,4 @@
-<%= _.camelize(appname) %>.<%= _.classify(name) %>Collection = Backbone.Collection.extend({
+<%= _.camelize(appname) %>.Collections.<%= _.classify(name) %>Collection = Backbone.Collection.extend({
 
   model: <%= _.camelize(appname) %>.<%= _.classify(name) %>Model
 

--- a/lib/generators/backbone/templates/model.js
+++ b/lib/generators/backbone/templates/model.js
@@ -1,3 +1,3 @@
-<%= _.camelize(appname) %>.<%= _.classify(name) %>Model = Backbone.Model.extend({
+<%= _.camelize(appname) %>.Models.<%= _.classify(name) %>Model = Backbone.Model.extend({
 
 });

--- a/lib/generators/backbone/templates/router.js
+++ b/lib/generators/backbone/templates/router.js
@@ -1,3 +1,3 @@
-<%= grunt.util._.camelize(appname) %>.Router = Backbone.Router.extend({
+<%= grunt.util._.camelize(appname) %>.Routers.<%= _.classify(name) %>Router = Backbone.Router.extend({
 
 });

--- a/lib/generators/backbone/templates/view.js
+++ b/lib/generators/backbone/templates/view.js
@@ -1,4 +1,4 @@
-<%= grunt.util._.camelize(appname) %>.<%= grunt.util._.camelize(name) %>View = Backbone.View.extend({
+<%= grunt.util._.camelize(appname) %>.Views.<%= grunt.util._.camelize(name) %>View = Backbone.View.extend({
 
   //template: <%= grunt.util._.underscored(name) %>
 


### PR DESCRIPTION
When creating Backbone components through `yeoman init backbone:model`
the namespaces didn't match with the current one, also when creating
multiple router instances, their names would overlap each other.

example:

```
window.appName = {
  Models: {},
  Collections: {},
  Views: {},
  Routers: {},
  init: function() {
    console.log('Hello from Backbone!');
  }
};
```

```
yeoman init backbone:model user
```

The new model would live the `appName.userModel` namespace instead of `appName.Models.userModel`

About the Router.
It's possible to have multiple Router instances, although uncommon. 
the current Namespace model allows it by having `window.appName.Routers`, however when doing `yeoman init backbone:router widgetX` the generated file would be

```
appName.Router = Backbone.Router.extend({

});
```

This doesn't match the current namespace and doesn't allow multiple instances of the Router, since they would overwrite each other.

This situation has been fixed by generating a file with the current content:

```
appName.Routers.widgetXRouter = Backbone.Router.extend({

});
```

Feel free to disagree ;)
