### PR TITLE
Fixed a typo in .htaccess

### DIFF
--- a/lib/generators/quickstart/all/templates/app/.htaccess
+++ b/lib/generators/quickstart/all/templates/app/.htaccess
@@ -338,7 +338,7 @@ FileETag None
 # 'foo' is your directory.
 
 # If your web host doesn't allow the FollowSymlinks option, you may need to
-# comment it out and use `Options +SymLinksOfOwnerMatch`, but be aware of the
+# comment it out and use `Options +SymLinksIfOwnerMatch`, but be aware of the
 # performance impact: http://goo.gl/Mluzd
 
 <IfModule mod_rewrite.c>


### PR DESCRIPTION
`SymLinksIfOwnerMatch` option for `mod_rewrite` was `SymLinksOfOwnerMatch` in the description.
