### PR TITLE
Update bbb's readme.md to make it easier to read

### DIFF
--- a/lib/generators/bbb/readme.md
+++ b/lib/generators/bbb/readme.md
@@ -1,7 +1,6 @@
-
-name:     Backbone Boilerplate
-author:   Original project: Tim Branyen, Generator: Addy Osmani
-provides: HTML5 Boilerplate, jQuery, Backbone.js, Layout Manager, Mocha
+name:     Backbone Boilerplate  
+author:   Original project: Tim Branyen, Generator: Addy Osmani  
+provides: HTML5 Boilerplate, jQuery, Backbone.js, Layout Manager, Mocha  
 usage:    yeoman init bbb
 
 This boilerplate is the product of much research and frustration.  Existing


### PR DESCRIPTION
Add double whitespace to the end of lines to make text more readable at GitHub's pages.

Markdown's [syntax](http://daringfireball.net/projects/markdown/syntax#p) says: "When you do want to insert a break tag using Markdown, you end a line with two or more spaces, then type return."
