### PR TITLE
Ensure server is launched before tests

### DIFF
--- a/lib/generators/yeoman/app/templates/Gruntfile.js
+++ b/lib/generators/yeoman/app/templates/Gruntfile.js
@@ -180,6 +180,6 @@ module.exports = function( grunt ) {
   });
 
   // Alias the `test` task to run the `mocha` task instead
-  grunt.registerTask('test', '<%= test_framework %>');
+  grunt.registerTask('test', 'server:phantom <%= test_framework %>');
 
 };


### PR DESCRIPTION
This allows to have a dedicated server launched before running
headless tests.

See Issue #443 in `yeoman` repo.
