### PR TITLE
Changelog for v0.9.2 is ready!

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-### 0.9.21 (25 September, 2012)
+### 0.9.2 (25 September, 2012)
 
 * index.html conflict solved (Pull [#66](https://github.com/yeoman/generators/pull/66)).
 
@@ -14,9 +14,7 @@
 
 * angularjs: gets es5 shim and json3 conditionally for oldIE (Pull [#61](https://github.com/yeoman/generators/pull/61)).
 
-* Chrome Apps Generator gets few many fixes (Pull [#59](https://github.com/yeoman/generators/pull/59)).
+* Chrome Apps Generator gets a few many fixes (Pull [#59](https://github.com/yeoman/generators/pull/59)).
 
 * Fix for issues to do with library clobbering due to re-use of the scripts/vendor directory (Pull [#57](https://github.com/yeoman/generators/pull/57)).
-
-* Ensure server is launched before tests Pull ([#56](https://github.com/yeoman/generators/pull/56)).
 


### PR DESCRIPTION
### 0.9.2 (25 September, 2012)
- index.html conflict solved (Pull [#66](https://github.com/yeoman/generators/pull/66)).
- Update for grunt-coffee task (Pull [#62](https://github.com/yeoman/generators/pull/62)). 
- Generators now use app/components for bower installs (Issue [#65](https://github.com/yeoman/generators/issues/65)).
- Updated lodash to 0.7.0 and backbone.layoutmanager to 0.6.6 (Pull [#60](https://github.com/yeoman/generators/pull/60)).
- File collision menu, tests for individual generators, mocha:generator and better looking output (Pull [#63](https://github.com/yeoman/generators/pull/63)).
- Ensure server is launched before tests (Pull [#56](https://github.com/yeoman/generators/pull/56)).
- angularjs: gets es5 shim and json3 conditionally for oldIE (Pull [#61](https://github.com/yeoman/generators/pull/61)).
- Chrome Apps Generator gets few many fixes (Pull [#59](https://github.com/yeoman/generators/pull/59)).
- Fix for issues to do with library clobbering due to re-use of the scripts/vendor directory (Pull [#57](https://github.com/yeoman/generators/pull/57)).
