### PR TITLE
Angular:crud

### DIFF
--- a/lib/generators/angular/crud-controller/USAGE
+++ b/lib/generators/angular/crud-controller/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Creates a new Angular controller
+
+Example:
+    yeoman init angular:crud-controller thing action [--coffee]
+
+    This will create:
+        app/scripts/controllers/thing/thingAction.js

--- a/lib/generators/angular/crud-controller/index.js
+++ b/lib/generators/angular/crud-controller/index.js
@@ -1,0 +1,38 @@
+
+var path = require('path'),
+  util = require('util'),
+  ScriptBase = require('../script-base.js'),
+  grunt = require('grunt'),
+  angularUtils = require('../util.js'),
+  fs = require('fs');
+
+module.exports = Generator;
+
+function Generator() {
+  ScriptBase.apply(this, arguments);
+  
+  this.model = this.name;
+  this.name = this.filename = this.args[1];
+}
+
+util.inherits(Generator, ScriptBase);
+
+Generator.prototype.createControllerFiles = function createControllerFiles() {
+  this.template('controller', 'app/scripts/controllers/' + this.model + '/' + this.filename);
+  this.template('spec/controller', 'test/spec/controllers/' + this.model + '/' + this.filename);
+};
+
+Generator.prototype.rewriteIndexHtml = function() {
+  var file = 'app/index.html';
+  var body = grunt.file.read(file);
+  
+  body = angularUtils.rewrite({
+    needle: '<!-- endbuild -->',
+    haystack: body,
+    splicable: [
+      '<script src="scripts/controllers/' + this.model + '/' + this.filename + '.js"></script>'
+    ]
+  });
+
+  grunt.file.write(file, body);
+};

--- a/lib/generators/angular/crud-route/USAGE
+++ b/lib/generators/angular/crud-route/USAGE
@@ -1,0 +1,11 @@
+Description:
+    Creates a new AngularJS route
+
+Example:
+    yeoman init angular:crud-route thing action [--coffee]
+
+    This will create:
+        app/scripts/controllers/thing/thingAction.js
+        app/views/thing/thingAction.html
+    And add routing to:
+        app.js

--- a/lib/generators/angular/crud-route/index.js
+++ b/lib/generators/angular/crud-route/index.js
@@ -1,0 +1,50 @@
+
+var path = require('path'),
+  util = require('util'),
+  grunt = require('grunt'),
+  _ = grunt.util._,
+  yeoman = require('../../../../'),
+  angularUtils = require('../util.js');
+
+module.exports = Generator;
+
+function Generator() {
+  yeoman.generators.NamedBase.apply(this, arguments);
+  this.sourceRoot(path.join(__dirname, '../templates'));
+
+  this.appname = path.basename(process.cwd());
+  
+  this.action = this.args[1];
+  if(this.action == 'view' || this.action == 'update'){
+    this.action += '/:id';
+  }
+  
+  this.filename = this.name + this.args[1].charAt(0).toUpperCase() + this.args[1].substr(1);
+ 
+  this.hookFor('angular:crud-controller', {
+    args: [this.name, this.filename]
+  });
+  this.hookFor('angular:crud-view', {
+    args: [this.name, this.filename]
+  });
+}
+
+util.inherits(Generator, yeoman.generators.NamedBase);
+
+Generator.prototype.rewriteAppJs = function() {
+  var file = 'app/scripts/app.js'; // TODO: coffee
+  var body = grunt.file.read(file);
+  
+  body = angularUtils.rewrite({
+    needle: '.otherwise',
+    haystack: body,
+    splicable: [
+      ".when('/" + this.name + "/" + this.action + "', {",
+      "  templateUrl: 'views/" + this.name + "/" + this.filename + ".html',",
+      "  controller: '" + _.classify(this.filename) + "Ctrl'",
+      "})"
+    ]
+  });
+
+  grunt.file.write(file, body);
+};

--- a/lib/generators/angular/crud-view/USAGE
+++ b/lib/generators/angular/crud-view/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Creates a new AngularJS view
+
+Example:
+    yeoman init angular:crud-view thing action
+
+    This will create:
+        app/scripts/views/thing/thingAction.html

--- a/lib/generators/angular/crud-view/index.js
+++ b/lib/generators/angular/crud-view/index.js
@@ -1,0 +1,21 @@
+
+var path = require('path'),
+  util = require('util'),
+  yeoman = require('../../../../');
+
+module.exports = Generator;
+
+function Generator() {
+  yeoman.generators.NamedBase.apply(this, arguments);
+  this.sourceRoot(path.join(__dirname, '../templates'));
+
+  this.appname = path.basename(process.cwd());
+  
+  this.filename = this.args[1];
+}
+
+util.inherits(Generator, yeoman.generators.NamedBase);
+
+Generator.prototype.createViewFiles = function createViewFiles() {
+  this.template('common/view.html', 'app/views/' + this.name  + '/' + this.filename + '.html');
+};

--- a/lib/generators/angular/crud/USAGE
+++ b/lib/generators/angular/crud/USAGE
@@ -1,0 +1,21 @@
+Description:
+    Creates new AngularJS crud routes
+
+Example:
+    yeoman init angular:crud thing [--coffee]
+
+    This will create:
+        app/scripts/controllers/thing/thingIndex.js
+        app/scripts/controllers/thing/thingCreate.js
+        app/scripts/controllers/thing/thingUpdate.js
+        app/scripts/controllers/thing/thingView.js
+        app/views/thing/thingIndex.html
+        app/views/thing/thingCreate.html
+        app/views/thing/thingUpdate.html
+        app/views/thing/thingView.html
+    And add routing to:
+        app.js
+		/thing/index
+		/thing/create
+		/thing/update/:id
+		/thing/view/:id

--- a/lib/generators/angular/crud/index.js
+++ b/lib/generators/angular/crud/index.js
@@ -1,0 +1,28 @@
+var path = require('path'),
+  util = require('util'),
+  yeoman = require('../../../../');
+
+module.exports = Generator;
+
+function Generator() {
+  yeoman.generators.NamedBase.apply(this, arguments);
+
+  this.hookFor('angular:crud-route', {
+    args: [this.name, 'index']
+  });
+
+  this.hookFor('angular:crud-route', {
+    args: [this.name, 'create']
+  });
+
+  this.hookFor('angular:crud-route', {
+    args: [this.name, 'update']
+  });
+
+  this.hookFor('angular:crud-route', {
+    args: [this.name, 'view']
+  });
+
+}
+
+util.inherits(Generator, yeoman.generators.NamedBase);


### PR DESCRIPTION
Description:
    Creates new AngularJS crud routes

Example:
    yeoman init angular:crud thing [--coffee]

```
This will create:
    app/scripts/controllers/thing/thingIndex.js
    app/scripts/controllers/thing/thingCreate.js
    app/scripts/controllers/thing/thingUpdate.js
    app/scripts/controllers/thing/thingView.js
    app/views/thing/thingIndex.html
    app/views/thing/thingCreate.html
    app/views/thing/thingUpdate.html
    app/views/thing/thingView.html
And add routing to:
    app.js
    /thing/index
    /thing/create
    /thing/update/:id
    /thing/view/:id
```

@btford Here we have the ability to generate all crud routes in one command. Further, they will be organized into folders and the routes will look better. 
