### PR TITLE
Fixing yeoman/yeoman#622

### DIFF
--- a/lib/generators/angular/templates/common/app/Gruntfile.js
+++ b/lib/generators/angular/templates/common/app/Gruntfile.js
@@ -10,11 +10,6 @@ module.exports = function( grunt ) {
     // Project configuration
     // ---------------------
 
-    // specify an alternate install location for Bower
-    bower: {
-      dir: 'app/components'
-    },
-
     // Coffee to JS compilation
     coffee: {
       compile: {

--- a/lib/generators/backbone/app/templates/Gruntfile.js
+++ b/lib/generators/backbone/app/templates/Gruntfile.js
@@ -10,11 +10,6 @@ module.exports = function( grunt ) {
     // Project configuration
     // ---------------------
 
-    // specify an alternate install location for Bower
-    bower: {
-      dir: 'app/components'
-    },
-
     // Coffee to JS compilation
     coffee: {
       compile: {

--- a/lib/generators/bbb/all/templates/Gruntfile.js
+++ b/lib/generators/bbb/all/templates/Gruntfile.js
@@ -10,11 +10,6 @@ module.exports = function( grunt ) {
     // Project configuration
     // ---------------------
 
-    // specify an alternate install location for Bower
-    bower: {
-      dir: 'app/components'
-    },
-
     // Coffee to JS compilation
     coffee: {
       compile: {

--- a/lib/generators/chromeapp/all/templates/Gruntfile.js
+++ b/lib/generators/chromeapp/all/templates/Gruntfile.js
@@ -10,11 +10,6 @@ module.exports = function( grunt ) {
     // Project configuration
     // ---------------------
 
-    // specify an alternate install location for Bower
-    bower: {
-      dir: 'app/components'
-    },
-
     // Coffee to JS compilation
     coffee: {
       compile: {

--- a/lib/generators/ember-starter/templates/Gruntfile.js
+++ b/lib/generators/ember-starter/templates/Gruntfile.js
@@ -10,11 +10,6 @@ module.exports = function( grunt ) {
     // Project configuration
     // ---------------------
 
-    // specify an alternate install location for Bower
-    bower: {
-      dir: 'app/components'
-    },
-
     // Coffee to JS compilation
     coffee: {
       compile: {

--- a/lib/generators/ember/app/templates/Gruntfile.js
+++ b/lib/generators/ember/app/templates/Gruntfile.js
@@ -10,11 +10,6 @@ module.exports = function( grunt ) {
     // Project configuration
     // ---------------------
 
-    // specify an alternate install location for Bower
-    bower: {
-      dir: 'app/components'
-    },
-
     // Coffee to JS compilation
     coffee: {
       compile: {

--- a/lib/generators/quickstart/all/templates/Gruntfile.js
+++ b/lib/generators/quickstart/all/templates/Gruntfile.js
@@ -10,11 +10,6 @@ module.exports = function( grunt ) {
     // Project configuration
     // ---------------------
 
-    // specify an alternate install location for Bower
-    bower: {
-      dir: 'app/components'
-    },
-
     // Coffee to JS compilation
     coffee: {
       compile: {

--- a/lib/generators/yeoman/app/index.js
+++ b/lib/generators/yeoman/app/index.js
@@ -106,6 +106,10 @@ AppGenerator.prototype.git = function git() {
   this.copy('gitattributes', '.gitattributes');
 };
 
+AppGenerator.prototype.bower = function bower() {
+  this.copy('bowerrc', '.bowerrc');
+};
+
 AppGenerator.prototype.jshint = function jshint() {
   this.copy('jshintrc', '.jshintrc');
 };

--- a/lib/generators/yeoman/app/templates/Gruntfile.js
+++ b/lib/generators/yeoman/app/templates/Gruntfile.js
@@ -10,16 +10,11 @@ module.exports = function( grunt ) {
     // Project configuration
     // ---------------------
 
-    // specify an alternate install location for Bower
-    bower: {
-      dir: 'app/components'
-    },
-
     // Coffee to JS compilation
     coffee: {
       compile: {
         files: {
-          'temp/scripts/*.js': 'app/scripts/**/*.coffee' 
+          'temp/scripts/*.js': 'app/scripts/**/*.coffee'
         },
         options: {
           basePath: 'app/scripts'

--- a/lib/generators/yeoman/app/templates/bowerrc
+++ b/lib/generators/yeoman/app/templates/bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "app/components"
+}


### PR DESCRIPTION
As describe this one should fix yeoman/yeoman#622: it creates a `.bowerrc` which indicates to bower that installed files should go in `app/components`
