### PR TITLE
issue #419 Fixing issue with paths to assets in compass

### DIFF
--- a/lib/generators/angular/templates/common/app/Gruntfile.js
+++ b/lib/generators/angular/templates/common/app/Gruntfile.js
@@ -29,6 +29,7 @@ module.exports = function( grunt ) {
           sass_dir: 'app/styles',
           images_dir: 'app/images',
           javascripts_dir: 'temp/scripts',
+          relative_assets: true,
           force: true
         }
       }

--- a/lib/generators/backbone/app/templates/Gruntfile.js
+++ b/lib/generators/backbone/app/templates/Gruntfile.js
@@ -31,6 +31,7 @@ module.exports = function( grunt ) {
           sass_dir: 'app/styles',
           images_dir: 'app/images',
           javascripts_dir: 'temp/scripts',
+          relative_assets: true,
           force: true
         }
       }

--- a/lib/generators/bbb/all/templates/Gruntfile.js
+++ b/lib/generators/bbb/all/templates/Gruntfile.js
@@ -31,6 +31,7 @@ module.exports = function( grunt ) {
           sass_dir: 'app/styles',
           images_dir: 'app/images',
           javascripts_dir: 'temp/scripts',
+          relative_assets: true,
           force: true
         }
       }

--- a/lib/generators/chromeapp/all/templates/Gruntfile.js
+++ b/lib/generators/chromeapp/all/templates/Gruntfile.js
@@ -31,6 +31,7 @@ module.exports = function( grunt ) {
           sass_dir: 'app/styles',
           images_dir: 'app/images',
           javascripts_dir: 'temp/scripts',
+          relative_assets: true,
           force: true
         }
       }

--- a/lib/generators/ember-starter/templates/Gruntfile.js
+++ b/lib/generators/ember-starter/templates/Gruntfile.js
@@ -31,6 +31,7 @@ module.exports = function( grunt ) {
           sass_dir: 'app/styles',
           images_dir: 'app/images',
           javascripts_dir: 'temp/scripts',
+          relative_assets: true,
           force: true
         }
       }

--- a/lib/generators/ember/app/templates/Gruntfile.js
+++ b/lib/generators/ember/app/templates/Gruntfile.js
@@ -31,6 +31,7 @@ module.exports = function( grunt ) {
           sass_dir: 'app/styles',
           images_dir: 'app/images',
           javascripts_dir: 'temp/scripts',
+          relative_assets: true,
           force: true
         }
       }

--- a/lib/generators/quickstart/all/templates/Gruntfile.js
+++ b/lib/generators/quickstart/all/templates/Gruntfile.js
@@ -31,6 +31,7 @@ module.exports = function( grunt ) {
           sass_dir: 'app/styles',
           images_dir: 'app/images',
           javascripts_dir: 'temp/scripts',
+          relative_assets: true,
           force: true
         }
       }

--- a/lib/generators/yeoman/app/templates/Gruntfile.js
+++ b/lib/generators/yeoman/app/templates/Gruntfile.js
@@ -31,6 +31,7 @@ module.exports = function( grunt ) {
           sass_dir: 'app/styles',
           images_dir: 'app/images',
           javascripts_dir: 'temp/scripts',
+          relative_assets: true,
           force: true
         }
       }


### PR DESCRIPTION
Done by feeding compass the relative_assets: true option in every generator that has a Gruntfile.js with a compass: dist: options section, like so:

``` javascript
compas: {
    dist: {
        options: {
            ...
            relative_assets: true,
            ...
```
