### PR TITLE
searchPath parameter for wiring.appendFiles

### DIFF
--- a/lib/actions/wiring.js
+++ b/lib/actions/wiring.js
@@ -69,17 +69,27 @@ wiring.prependToFile = function prependToFile(path, tagName, content) {
 // - optimizedPath  - the final file to build
 // - filesBlock     - a string containing populated script/style tags ready to be
 //                    injected into a usemin block.
+// - searchPath     - an alternate search path to look in for files
 //
 // Returns the new block.
-wiring.generateBlock = function generateBlock(blockType, optimizedPath, filesBlock) {
-  var blockStart = '\n        <!-- build:' + blockType + ' ' + optimizedPath + ' -->\n';
-  var blockEnd = '        <!-- endbuild -->\n';
+wiring.generateBlock = function generateBlock(blockType, optimizedPath, filesBlock, searchPath) {
+  var blockStart, blockEnd;
+  var blockSearchPath = '';
+
+  if (searchPath !== undefined) {
+    blockSearchPath = '(' + searchPath +  ')';
+  }
+
+  blockStart = '\n        <!-- build:' + blockType + blockSearchPath + ' ' + optimizedPath + ' -->\n';
+  blockEnd = '        <!-- endbuild -->\n';
   return blockStart + filesBlock + blockEnd;
 };
 
 // Append files, specifying the optimized path and generating the necessary
 // usemin blocks to be used for the build process.
 //
+// - htmlOrOptions  - string to append the files to or an object of this and
+//                    the remaining options
 // - fileType       - js (appends to the end of 'body'), css (appends to the
 //                    end of 'head')
 // - optimizedPath  - the final file to build
@@ -88,11 +98,22 @@ wiring.generateBlock = function generateBlock(blockType, optimizedPath, filesBlo
 //                    them and the right usemin blocks generated.
 // - attrs          - A Hash of html attributes to generate along the generated
 //                    script / link tags
+// - searchPath     - an alternate path to look in for files
 //
 // Returns updated content.
-wiring.appendFiles = function appendFiles(html, fileType, optimizedPath, sourceFileList, attrs) {
+wiring.appendFiles = function appendFiles(htmlOrOptions, fileType, optimizedPath, sourceFileList, attrs, searchPath) {
   var blocks, updatedContent;
+  var html = htmlOrOptions;
   var files = '';
+
+  if (typeof htmlOrOptions === 'object') {
+    html = htmlOrOptions.html;
+    fileType = htmlOrOptions.fileType;
+    optimizedPath = htmlOrOptions.optimizedPath;
+    sourceFileList = htmlOrOptions.sourceFileList;
+    attrs = htmlOrOptions.attrs;
+    searchPath = htmlOrOptions.searchPath;
+  }
 
   attrs = this.attributes(attrs);
 
@@ -100,13 +121,13 @@ wiring.appendFiles = function appendFiles(html, fileType, optimizedPath, sourceF
     sourceFileList.forEach(function (el) {
         files += '        <script ' + attrs + ' src="' + el + '"></script>\n';
     });
-    blocks = this.generateBlock('js', optimizedPath, files);
+    blocks = this.generateBlock('js', optimizedPath, files, searchPath);
     updatedContent = this.append(html, 'body', blocks);
   } else if (fileType === 'css') {
     sourceFileList.forEach(function(el) {
         files += '        <link ' + attrs + ' rel="stylesheet" href="' + el  + '">\n';
     });
-    blocks = this.generateBlock('css', optimizedPath, files);
+    blocks = this.generateBlock('css', optimizedPath, files, searchPath);
     updatedContent = this.append(html, 'head', blocks);
   }
 
@@ -139,7 +160,7 @@ wiring.appendStyles = function appendStyles(html, optimizedPath, sourceFileList,
   return this.appendFiles(html, 'css', optimizedPath, sourceFileList, attrs);
 };
 
-wiring.removeStyle = function removeStyle( html, path ) {
+wiring.removeStyle = function removeStyle(html, path) {
   return this.domUpdate(html, 'link[href$="' + path + '"]' , '', 'd');
 };
 

--- a/test/fixtures/js_block.html
+++ b/test/fixtures/js_block.html
@@ -1,0 +1,6 @@
+<html><body>
+        <!-- build:js out/file.js -->
+        <script src="in/file1.js"></script>
+        <script src="in/file2.js"></script>
+        <!-- endbuild -->
+</body></html>

--- a/test/wiring.js
+++ b/test/wiring.js
@@ -1,0 +1,52 @@
+/*global describe before it */
+var path = require('path');
+var fs = require('fs');
+var events = require('events');
+var assert = require('assert');
+var wiring = require('../lib/actions/wiring');
+
+describe('yeoman.generator.lib.actions.wiring', function () {
+  before(function () {
+    this.fixtures = path.join(__dirname, 'fixtures');
+  });
+
+  it('should generate a simple block', function () {
+    var res = wiring.generateBlock('js', 'main.js', [
+      'path/file1.js',
+      'path/file2.js'
+    ]);
+
+    assert.equal(res.trim(), '<!-- build:js main.js -->\npath/file1.js,path/file2.js        <!-- endbuild -->');
+  });
+
+  it('should generate a simple block with search path', function () {
+    var res = wiring.generateBlock('js', 'main.js', [
+      'path/file1.js',
+      'path/file2.js'
+    ], '.tmp/');
+
+    assert.equal(res.trim(), '<!-- build:js(.tmp/) main.js -->\npath/file1.js,path/file2.js        <!-- endbuild -->');
+  });
+
+  it('should append js files to an html string', function () {
+    var html = '<html><body></body></html>';
+    var res = wiring.appendFiles(html, 'js', 'out/file.js', ['in/file1.js', 'in/file2.js']);
+    var fixture = fs.readFileSync(path.join(this.fixtures, 'js_block.html'),
+                                  'utf-8').trim();
+
+    assert.equal(res, fixture);
+  });
+
+  it('appendFiles should work the same using the object syntax', function () {
+    var html = '<html><body></body></html>';
+    var res = wiring.appendFiles(html, 'js', 'out/file.js', ['in/file1.js', 'in/file2.js']);
+    var res2 = wiring.appendFiles({
+      html: html,
+      fileType: 'js',
+      optimizedPath: 'out/file.js',
+      sourceFileList: ['in/file1.js', 'in/file2.js']
+    });
+
+    assert.equal(res, res2);
+  });
+});


### PR DESCRIPTION
This adds support for adding an alternative search path to `wiring.appendFiles` as described in #176(*). Because `searchPath` is now the sixth parameter to the function I thought I would be wise to allow passing an object instead, especially since `attrs` is optional. I chose to not update the shorthands for this, because this is probably a rarely used feature.

(*) where I can't append code to, because github's API is throwing an HTTP 500 at me. :angry: 
