### PR TITLE
Update Bower dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "nopt": "~2.1.1",
     "cli-table": "~0.2.0",
     "debug": "~0.7.0",
-    "bower": "~0.7.0",
+    "bower": "~0.8.5",
     "isbinaryfile": "~0.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes `Arguments to path.join must be strings` error in node 0.10.0 when running `yo [generator-name]`.

Related to twitter/bower#270.
