### PR TITLE
adding `log.error` to complement `log.ok`

### DIFF
--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -100,6 +100,11 @@ module.exports = function logger() {
     return this;
   };
 
+  log.error = function (msg) {
+    this.write('✗ '.red + util.format.apply(util, arguments) + '\n');
+    return this;
+  };
+
   log.on('up', function () {
     padding = padding + step;
   });


### PR DESCRIPTION
log.error appends a red x, the same as log.ok appends a green check.
