### PR TITLE
Improved error message when generator is not found

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -330,8 +330,10 @@ Environment.prototype.create = function create(namespace, options) {
   if (!generator) {
     return this.error(
       new Error(
-        'Invalid namespace: ' + namespace + ' (or not yet registered).' +
-        '\n Registered: ' + this.namespaces().length + ' namespace(s). Run with the `--help` option to list them.'
+        'You don\'t seem to have a generator with the name ' + namespace + ' installed.\n' +
+        'You can see available generators with ' + 'npm search yeoman-generator'.bold +
+        ' and then install them with ' + 'npm install [name]'.bold + '.\n' +
+        'To see the ' + this.namespaces().length + ' registered generators run yo with the `--help` option.'
       )
     );
   }


### PR DESCRIPTION
As discussed in #196, this replaces the use of "namespace" with generator and provides instructions how to find and install a missing generator.

![Screenshot from 2013-03-26 18:17:31](https://f.cloud.github.com/assets/9906/304307/75e77efc-9639-11e2-9860-ec907ea3ca27.png)
