### PR TITLE
Filter option for actions.prompt

### DIFF
--- a/lib/actions/prompt.js
+++ b/lib/actions/prompt.js
@@ -1,37 +1,73 @@
-var read = require('read');
+'use strict';
 
-var prompt = module.exports;
+var prompt_ = require('prompt');
+var _ = require('lodash');
+var exports = module.exports;
+
+
+function evaluatePrompts(prompt) {
+  if (_.isFunction(prompt.default)) {
+    prompt.default = prompt.default();
+  } else if (prompt.default === true || prompt.default === false) {
+    // Handle boolean defaults as confirmation prompts.
+    var defaultMsg = prompt.default ? 'Y/n' : 'y/N';
+    prompt.default = defaultMsg;
+
+    prompt.validator = function (value) {
+      return value.match(/^([yYnN]|(y\/N)|(Y\/n))$/);
+    };
+    prompt.required = true;
+
+    prompt.before = function (val) {
+      if (val === 'Y/n' || val.toLowerCase() === 'y') {
+        return true;
+      } else if (val === 'y/N' || val.toLowerCase() === 'n') {
+        return false;
+      }
+
+      return val;
+    };
+  }
+
+  return prompt;
+}
 
 // Prompt for user input based on the given Array of `prompts` to perform in
 // series, and call `done` callback on completion.  `prompts` can be a single
 // Hash of options in which case a single prompt is performed.
 //
-// Options can be any read's option: https://github.com/isaacs/read#options
+// Options can be any prompt's option: https://npmjs.org/package/prompt
 //
 // - prompts    - A single or an Array of Hash options.
 // - done       - Callback to call on error or on completion.
 //
 // Returns the generator instance.
-prompt.prompt = function prompt(prompts, done) {
+exports.prompt = function prompt(prompts, done) {
   prompts = Array.isArray(prompts) ? prompts : [prompts];
+
+  prompts = prompts.map(evaluatePrompts);
+
+  prompt_.message = '[' + '?'.green + ']';
+  prompt_.delimiter = ' ';
+  prompt_.start();
 
   var results = {};
   (function next(prompt) {
+    function handleResult(err, value) {
+      if (err) {
+        return done(err);
+      }
+
+      results[prompt.name] = value;
+      next(prompts.shift());
+    }
+
     if (!prompt) {
       return done(null, results);
     }
 
-    if (!prompt.prompt) {
-      prompt.prompt = prompt.message;
-    }
-
-    read(prompt, function (err, value) {
-      if (err) {
-        return done(err);
-      }
-      results[prompt.name] = value;
-      next(prompts.shift());
-    });
+    prompt_.get(prompt, handleResult);
   })(prompts.shift());
+
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "underscore.string": "~2.3.1",
     "lodash": "~1.1.1",
     "mkdirp": "~0.3.5",
-    "read": "~1.0.4",
     "glob": "~3.1.21",
     "nopt": "~2.1.1",
     "cli-table": "~0.2.0",
     "debug": "~0.7.2",
-    "isbinaryfile": "~0.1.8"
+    "isbinaryfile": "~0.1.8",
+    "prompt": "~0.2.9"
   },
   "devDependencies": {
     "mocha": "~1.9.0",


### PR DESCRIPTION
I would like to propose a feature I found while digging around in `grunt-init` that did not have an equivalent in Yeoman.

The prompt should accept a `filter` option that allows to sanitize, validate or manipulate the value provided by the user.
### Example Usage

```
var prompts = [{
  name: 'title',
  message: 'Project Title:',
  filter: function (value, cb) {
    // Callback expects (err, newValue)
    cb(null, value.replace(/jquery/i, 'jQuery'));
  }
}];
```
### Benefit

While sanitizing data is already possible after the prompt is finished in the callback, this way makes it clearer to see where the manipulation is happening. Also, this allows to abort early if a value fails to validate.
