### PR TITLE
options to pass test-framework and coffee to the createGenerator in test-helper

### DIFF
--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -156,6 +156,7 @@ helpers.createDummyGenerator = function() {
 //
 helpers.createGenerator = function ( name, dependencies, args) {
   var env = generators();
+  var arg = {};
   dependencies.forEach(function(d) {
     if (d instanceof Array) {
       env.register(d[0], d[1]);
@@ -164,7 +165,18 @@ helpers.createGenerator = function ( name, dependencies, args) {
     }
   });
 
-  var generator = env.create(name, {arguments: args});
+  args = args || [];
+
+  if(Array.isArray(args)){
+    arg.args = args;
+    arg.options = {};
+  }
+
+  if(typeof(args) === 'object'){
+    arg = args;
+  }
+
+  var generator = env.create(name, {arguments: arg.args , options: arg.options });
 
   generator.on('start', env.emit.bind(this, 'generators:start'));
   generator.on('start', env.emit.bind(this, name + ':start'));


### PR DESCRIPTION
This will help to pass options to createGenerator in test

``` js
var app = helpers.createGenerator('backbone:app', [
      '../../app', [
        helpers.createDummyGenerator(),
        'jasmine:app'
      ]
    ], {args: ['hello'], options: {'test-framework': 'jasmine'}});

```

This fix is also backward compatible, so won't break the existing tests for other generators.

Thanks.
