### PR TITLE
Remove bower dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - 0.8
+before_script:
+  npm install -g bower
 # notifications:
 #   irc:
 #     channels:

--- a/lib/actions/bower.js
+++ b/lib/actions/bower.js
@@ -1,10 +1,40 @@
-var commands = require('bower').commands;
-
+var spawn = require('child_process').spawn;
 var bower = module.exports;
+var _ = require('lodash');
 
-// TODO(mklabs): bower has quite a few dependencies, just like npm, consider
-// spawning the `bower` command instead, with some gracefull fallback to
-// local `./node_modules/.bin` folder and error handling
+
+// Convert an object to an array of CLI arguments
+function optsToArgs(options) {
+  var args = [];
+
+  Object.keys(options).forEach(function (flag) {
+    var val = options[flag];
+
+    flag = flag.replace(/[A-Z]/g, function (match) {
+      return '-' + match.toLowerCase();
+    });
+
+    if (val === true) {
+      args.push('--' + flag);
+    }
+
+    if (_.isString(val)) {
+      args.push('--' + flag, val);
+    }
+
+    if (_.isNumber(val)) {
+      args.push('--' + flag, '' + val);
+    }
+
+    if (_.isArray(val)) {
+      val.forEach(function (arrVal) {
+        args.push('--' + flag, arrVal);
+      });
+    }
+  });
+
+  return args;
+}
 
 // Receives a list of `paths`, and an Hash of `options` to install through bower
 //
@@ -23,11 +53,17 @@ bower.install = function install(paths, options, cb) {
   paths = Array.isArray(paths) ? paths : (paths && paths.split(' ') || []);
 
   this.emit('install', paths);
-  commands.install(paths, options)
-    .on('data', console.error.bind(console))
-    .on('error', cb)
-    .on('end', cb)
-    .on('end', this.emit.bind(this, 'install:end', paths));
+
+  spawn('bower', ['install'].concat(paths).concat(optsToArgs(options)))
+    .on('err', cb)
+    .on('exit', this.emit.bind(this, 'install:end', paths))
+    .on('exit', function (err) {
+      if (err === 127) {
+        this.log.error('Could not find bower. Please install with ' +
+                       '`npm install -g bower`.');
+      }
+      cb(err);
+    }.bind(this));
 
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "nopt": "~2.1.1",
     "cli-table": "~0.2.0",
     "debug": "~0.7.0",
-    "bower": "~0.8.5",
     "isbinaryfile": "~0.1.5"
   },
   "devDependencies": {
-    "mocha": "~1.8.1"
+    "mocha": "~1.8.1",
+    "proxyquire": "~0.4.0"
   }
 }

--- a/test/actions.js
+++ b/test/actions.js
@@ -4,6 +4,7 @@ var path = require('path');
 var util = require('util');
 var events = require('events');
 var assert = require('assert');
+var proxyquire = require('proxyquire');
 var generators = require('../');
 var eol = require('os').EOL;
 
@@ -177,6 +178,50 @@ describe('yeoman.generators.Base', function () {
       var body = fs.readFileSync('directory/foo-template.js', 'utf8');
       var foo = this.dummy.foo;
       assert.equal(body, 'var ' + foo + ' = \'' + foo + '\';' + eol);
+    });
+  });
+
+  describe('generator.install', function () {
+    var asyncStub = {
+      on: function (key, cb) {
+        if (key === 'exit') {
+          cb();
+        }
+        return asyncStub;
+      }
+    };
+
+    it('should spawn a bower process', function (done) {
+
+      function spawn(cmd, args) {
+        assert.equal(cmd, 'bower');
+        assert.deepEqual(args, ['install']);
+
+        return asyncStub;
+      }
+
+      var bower = proxyquire('../lib/actions/bower', {
+        child_process: {spawn: spawn}
+      });
+
+      bower.emit = function () {};
+      bower.install(null, done);
+    });
+
+    it('should spawn a bower process with formatted options', function (done) {
+
+      function spawn(cmd, args) {
+        assert.equal(cmd, 'bower');
+        assert.deepEqual(args, ['install', 'jquery', '--save-dev']);
+        return asyncStub;
+      }
+
+      var bower = proxyquire('../lib/actions/bower', {
+        child_process: {spawn: spawn}
+      });
+
+      bower.emit = function () {};
+      bower.install('jquery', {saveDev: true}, done);
     });
   });
 });


### PR DESCRIPTION
After some hours of profiling I found that the `bower` dependency accounted for a substantial part of the start-up time. After removing bower a stripped-down version of `generator-webapp` ran in 0.3s compared to 1.7s with bower. For poor Sindre, who's still running on an HDD, the startup time went from 24s to 1.25s.

The reason for this is that bower is recursively required by all sub-generators and bower itself has quite a lot of dependencies, causing more than 22 000 synchronous stat syscalls when looking up dependent modules in my test case with two sub-generators.

This patch removes the bower dependency and uses `childprocess.spawn` instead to provide the same functionality, as suggested by @mklabs.

EDIT: 
#### _Scientific comparison_

![2013-04-08 00 14 56](https://f.cloud.github.com/assets/9906/349558/cff9f078-9fd0-11e2-85b1-690b1585ecac.jpg)
