### PR TITLE
generator appname set to cwd, not package.name

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -68,7 +68,7 @@ var Base = module.exports = function Base(args, options) {
   this._hooks = [];
   this._warns = [];
   this._conflicts = [];
-  this.appname = path.basename(process.cwd()).replace(/[^\w\s]+?/g, ' ');
+  this.appname = require([process.cwd(), 'package.json'].join('/')).name || path.basename(process.cwd()).replace(/[^\w\s]+?/g, ' ');
 
   this.option('help', {
     alias: 'h',


### PR DESCRIPTION
It seems that appname is set to the current working directory, rather than the package.name. While this shouldn't affect those who continue to use the package.name that is generated when scaffolding, I modify my package.name, and I'd like the generators to continue to use this name. I think it's more semantically and conceptually accurate to use the package.name and not the name of the current working directory
