### PR TITLE
Add generators directory to lookups

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -49,6 +49,7 @@ var Environment = module.exports = function Environment(args, opts) {
   this.lookups = [];
   this.paths = [];
   this.appendLookup('.');
+  this.appendLookup('generators');
   this.appendLookup('lib/generators');
 
   this.appendPath('.');


### PR DESCRIPTION
@necolas brought up a good point on IRC about placing your generators in a generators folder  in your root together with a templates folder for instance. This would enable those who want to cleanly separate the generator code from the templates. There's already `lib/generators` in there now. Don't know if we should have both.

```
generators
    ˪ app
        ˪ index.js 
    controller
        ˪ index.js
templates
    ˪ index.html
    gruntfile.js
```

or below which can be done right now

```
lib 
    ˪ generators
        ˪ app
            ˪ index.js 
        controller
            ˪ index.js
    ˪ templates
        ˪ index.html
        gruntfile.js
```

Maybe there needs to be some set convention on how to structure generators too.

@btford @kevva @sindresorhus @addyosmani
