### PR TITLE
fix issue with prompt when file conflict occours

### DIFF
--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var events = require('events');
 var diff = require('diff');
-var prompt = require('../actions/prompt').prompt;
+var prompt = require('../actions/prompt');
 var exists = fs.existsSync || path.existsSync;
 var log = logger('conflicter');
 


### PR DESCRIPTION
Solves the **prompt** undefined issue, on file conflict.

![yeoman-prompt-conflict](https://f.cloud.github.com/assets/463904/387064/ea6beac8-a6b6-11e2-8a1b-b4b143b768cb.png)
