### PR TITLE
Fix async waiter race condition

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -231,6 +231,7 @@ Base.prototype.run = function run(args, cb) {
   // us to perform test in a synchronous way -- i.e. without prompting user)
   methods.push(-1);
 
+  var waiter = 0;
   (function next(method) {
     if (!method) {
       return;
@@ -251,7 +252,6 @@ Base.prototype.run = function run(args, cb) {
     // very very basic async management, could be done better using event and
     // EventEmitter ability of Generators.
 
-    var waiter = 0;
     self.async = function async() {
       waiter++;
       return function (err) {


### PR DESCRIPTION
I believe that `waiter` is incorrectly initialized, because it was reset every time the a `next()` tick what happen, which could cause async pauses to get lost.

This came up in Kevin's PR at generator-generator which broke a test case: https://github.com/passy/generator-generator/pull/5

I'd really appreciate some feedback if I'm not completely on the wrong track.

/cc @kevva @sindresorhus
