### PR TITLE
Make spawnCommand and runInstall methods public

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -5,15 +5,28 @@ var win32 = process.platform === 'win32';
 
 var install = module.exports;
 
-
-function spawnCommand(command, args, cb) {
+// Normalize a command across OS and spawn it
+//
+// - command    - A String containing a command to run
+// - arguments  - An Array of arguments to pass the command
+//
+// Returns ChildProcess object (of the spawned command)
+install.spawnCommand = function (command, args) {
   var winCommand = win32 ? 'cmd' : command;
   var winArgs = win32 ? ['/c ' + command + ' ' + args.join(' ')] : args;
 
   return spawn(winCommand, winArgs, { stdio: 'inherit' });
-}
+};
 
-function runInstall(generator, installer, paths, options, cb) {
+// Combine package manager cmd line arguments and run the "install" command
+//
+// - installer - A String containing the name of the package manager to use
+// - paths     - A String or an Array of package name to install. Empty string for `npm install`
+// - options   - [optional] The Hash of options to invoke `npm install` with. See `npm help install`.
+// - callback  - [optional]
+//
+// Returns the generator instance.
+install.runInstall = function (installer, paths, options, cb) {
   if (!cb && _.isFunction(options)) {
     cb = options;
     options = {};
@@ -23,22 +36,22 @@ function runInstall(generator, installer, paths, options, cb) {
   cb = cb || function () {};
   paths = Array.isArray(paths) ? paths : (paths && paths.split(' ') || []);
 
-  generator.emit(installer + 'Install', paths);
+  this.emit(installer + 'Install', paths);
   var args = ['install'].concat(paths).concat(dargs(options));
 
-  spawnCommand(installer, args, cb)
+  install.spawnCommand(installer, args, cb)
     .on('err', cb)
-    .on('exit', generator.emit.bind(generator, installer + 'Install:end', paths))
+    .on('exit', this.emit.bind(this, installer + 'Install:end', paths))
     .on('exit', function (err) {
       if (err === 127) {
-        generator.log.error('Could not find ' + installer + '. Please install with ' +
+        this.log.error('Could not find ' + installer + '. Please install with ' +
                             '`npm install -g ' + installer + '`.');
       }
       cb(err);
     });
 
-  return generator;
-}
+  return this;
+};
 
 
 // Runs `npm` and `bower` in the generated directory concurrently and prints a
@@ -105,7 +118,7 @@ install.installDependencies = function (options) {
 //
 // Returns the generator instance.
 install.bowerInstall = function install(paths, options, cb) {
-  return runInstall(this, 'bower', paths, options, cb);
+  return this.runInstall('bower', paths, options, cb);
 };
 
 
@@ -117,5 +130,5 @@ install.bowerInstall = function install(paths, options, cb) {
 //
 // Returns the generator instance.
 install.npmInstall = function install(paths, options, cb) {
-  return runInstall(this, 'npm', paths, options, cb);
+  return this.runInstall('npm', paths, options, cb);
 };

--- a/test/actions.js
+++ b/test/actions.js
@@ -235,6 +235,12 @@ describe('yeoman.generators.Base', function () {
     });
 
     describe('generator.installDependencies', function () {
+
+      afterEach(function () {
+        var install = require("../lib/actions/install");
+        this.dummy._.extend(this.dummy, install);
+      });
+
       it('should spawn npm and bower', function () {
         var commandsRun = [];
 
@@ -278,10 +284,12 @@ describe('yeoman.generators.Base', function () {
         }
 
         var install = proxyquire('../lib/actions/install', {
-          child_process: { spawn: spawn }
+          child_process: {spawn: spawn}
         });
 
-        install.npmInstall.call(this.dummy, 'yo', { save: true });
+        var dummy = this.dummy._.extend(this.dummy, install);
+
+        install.npmInstall.call(dummy, 'yo', { save: true });
         assert.deepEqual(commandsRun.length, 1);
 
         emitter.emit('exit');


### PR DESCRIPTION
I think those method could really be useful for public usage. On some kind of generator, we may need access to some generic command line utility - or simply to wire up other package manager than Bower and npm.

The test suite ain't working on windows, so I'm not sure it's passing. I'll revise if anything after the TravisCI checkup.
