### PR TITLE
actions.copy should work with one argument

### DIFF
--- a/lib/actions/actions.js
+++ b/lib/actions/actions.js
@@ -59,8 +59,8 @@ actions.destinationRoot = function destinationRoot(root) {
 // (most likely cwd)
 actions.copy = function copy(source, destination) {
   var body;
-  source = this.isPathAbsolute(source) ? source : path.join(this.sourceRoot(), source);
   destination = destination || source;
+  source = this.isPathAbsolute(source) ? source : path.join(this.sourceRoot(), source);
 
   var encoding = null;
   if (!isBinaryFile(source)) {

--- a/test/actions.js
+++ b/test/actions.js
@@ -61,6 +61,7 @@ describe('yeoman.generators.Base', function () {
     before(function (done) {
       this.dummy.copy(path.join(__dirname, 'fixtures/foo.js'), 'write/to/bar.js');
       this.dummy.copy('foo.js', 'write/to/foo.js');
+      this.dummy.copy('foo-copy.js');
       this.dummy.copy(path.join(__dirname, 'fixtures/lodash-copy.js'), 'write/to/lodash.js');
       this.dummy.conflicter.resolve(done);
     });
@@ -75,6 +76,10 @@ describe('yeoman.generators.Base', function () {
 
     it('should allow to copy without using the templating (conficting with lodash/underscore)', function (done) {
       fs.stat('write/to/lodash.js', done);
+    });
+
+    it('should default the destination to the source filepath value', function (done) {
+      fs.stat('foo-copy.js', done);
     });
   });
 

--- a/test/fixtures/foo-copy.js
+++ b/test/fixtures/foo-copy.js
@@ -1,0 +1,1 @@
+var foo = 'foo';


### PR DESCRIPTION
Same behavior as actions.directory.

So that this:
  this.copy('Procfile', 'Procfile');

Can be written like this:
  this.copy('Procfile');
