### PR TITLE
Extracted 'spawn_command' into its own action module

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -1,22 +1,7 @@
 var _ = require('lodash');
-var spawn = require('child_process').spawn;
 var dargs = require('dargs');
-var win32 = process.platform === 'win32';
 
 var install = module.exports;
-
-// Normalize a command across OS and spawn it
-//
-// - command    - A String containing a command to run
-// - arguments  - An Array of arguments to pass the command
-//
-// Returns ChildProcess object (of the spawned command)
-install.spawnCommand = function (command, args) {
-  var winCommand = win32 ? 'cmd' : command;
-  var winArgs = win32 ? ['/c ' + command + ' ' + args.join(' ')] : args;
-
-  return spawn(winCommand, winArgs, { stdio: 'inherit' });
-};
 
 // Combine package manager cmd line arguments and run the "install" command
 //
@@ -39,7 +24,7 @@ install.runInstall = function (installer, paths, options, cb) {
   this.emit(installer + 'Install', paths);
   var args = ['install'].concat(paths).concat(dargs(options));
 
-  install.spawnCommand(installer, args, cb)
+  this.spawnCommand(installer, args, cb)
     .on('err', cb)
     .on('exit', this.emit.bind(this, installer + 'Install:end', paths))
     .on('exit', function (err) {

--- a/lib/actions/spawn_command.js
+++ b/lib/actions/spawn_command.js
@@ -1,0 +1,16 @@
+var spawn = require('child_process').spawn;
+var win32 = process.platform === 'win32';
+
+// Normalize a command across OS and spawn it
+//
+// - command    - A String containing a command to run
+// - arguments  - An Array of arguments to pass the command
+//
+// Returns ChildProcess object (of the spawned command)
+module.exports = function spawnCommand(command, args) {
+  var winCommand = win32 ? 'cmd' : command;
+  var winArgs = win32 ? ['/c ' + command + ' ' + args.join(' ')] : args;
+
+  return spawn(winCommand, winArgs, { stdio: 'inherit' });
+};
+

--- a/lib/base.js
+++ b/lib/base.js
@@ -90,6 +90,7 @@ _.extend(Base.prototype, require('./actions/string'));
 _.extend(Base.prototype, require('./actions/wiring'));
 Base.prototype.prompt = require('./actions/prompt');
 Base.prototype.invoke = require('./actions/invoke');
+Base.prototype.spawnCommand = require('./actions/spawn_command');
 
 // Adds an option to the set of generator expected options, only used to
 // generate generator usage. By default, generators get all the cli option


### PR DESCRIPTION
Moved spawnCommand into its own module and made the tests a lot DRYer. -41 lines, yay!
