### PR TITLE
Check for required arguments

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -190,6 +190,10 @@ Base.prototype.argument = function argument(name, config) {
   var value = config.type === Array ? this.args.slice(position) : this.args[position];
   value = position >= this.args.length ? config.defaults : value;
 
+  if (config.required && value === undefined) {
+    return this.emit('error', new Error('Did not provide required argument ' + name.bold + '!'));
+  }
+
   this[name] = value;
   return this;
 };

--- a/test/base.js
+++ b/test/base.js
@@ -94,6 +94,19 @@ describe('yeoman.generators.Base', function () {
 
       assert.deepEqual(this.dummy.bar, ['baz', 'bom']);
     });
+
+    it('should raise an error if required arguments are not provided', function (done) {
+      var dummy = new generators.Base([], {
+        env: this.env,
+        resolved: 'dummy:all'
+      }).on('error', function (ev) {
+        done();
+      });
+
+      dummy.argument('foo', {
+        required: true
+      });
+    });
   });
 
   describe('generator.option(name, config)', function () {


### PR DESCRIPTION
Found out that `name` in NamedBase is marked as required, but that flag wasn't enforced anywhere.

/ref #230
