### PR TITLE
Add a new public method runCommand(), more generic than runInstall(), that uses an hardcoded 'install' in the command to launch

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -20,8 +20,8 @@ install.runInstall = function (installer, paths, options, cb) {
 //
 // - script    - A String containing the name of the script to use
 // - action    - A String containing the action command
-// - paths     - A String or an Array of package name to install. Empty string for `npm install`
-// - options   - [optional] The Hash of options to invoke `npm install` with. See `npm help install`.
+// - paths     - A String or an Array of package name to install. Empty string for `npm action`
+// - options   - [optional] The Hash of options to invoke `npm action` with. See `npm help action`.
 // - callback  - [optional]
 //
 // Returns the generator instance.
@@ -34,13 +34,16 @@ install.runCommand = function (script, action, paths, options, cb) {
   options = options || {};
   cb = cb || function () {};
   paths = Array.isArray(paths) ? paths : (paths && paths.split(' ') || []);
+  // Name of the signal to emit, for ex. with script=npm, action=install,
+  // signal emitted will be `npmInstall` at start, and `npmInstall:end` at end
+  var signal = script + action.charAt(0).toUpperCase() + action.slice(1);
 
-  this.emit(script + action, paths);
+  this.emit(signal, paths);
   var args = [action].concat(paths).concat(dargs(options));
 
   this.spawnCommand(script, args, cb)
     .on('err', cb)
-    .on('exit', this.emit.bind(this, script + action + ':end', paths))
+    .on('exit', this.emit.bind(this, signal + ':end', paths))
     .on('exit', function (err) {
       if (err === 127) {
         this.log.error('Could not find ' + script + '. Please install it first!');


### PR DESCRIPTION
Hello,

Now, until 3 days, as the `runInstall()` is public (nice to be able to run it), why not add also a more generic public method that can run any command ?

The fact is, with `runInstall()`, it seems to use an hardcoded word which is `install` as first param for the package manager.
It would be nice to have an handy function in yeoman-generator to run any command (not only a package manager as`npm` or `bower`), with any params.

This PR shows the spirit of the modification it could be

Thanks for your feedback
