### PR TITLE
Update yeoman prompt to use Inquirer (Fix #228)

### DIFF
--- a/lib/actions/prompt.js
+++ b/lib/actions/prompt.js
@@ -1,116 +1,17 @@
 'use strict';
 
-var prompt_ = require('prompt');
-var _ = require('lodash');
-var validate = require('revalidator').validate;
-
-
-function evaluatePrompts(prompt) {
-  if (_.isFunction(prompt.default)) {
-    prompt.default = prompt.default();
-  } else if (typeof prompt.default === 'boolean') {
-    // Handle boolean defaults as confirmation prompts.
-    var defaultMsg = prompt.default ? 'Y/n' : 'y/N';
-    prompt.default = defaultMsg;
-
-    prompt.validator = function (value) {
-      return value.match(/^([yYnN]|(y\/N)|(Y\/n))$/);
-    };
-    prompt.required = true;
-
-    prompt.before = function (val) {
-      if (val === 'Y/n' || val.toLowerCase() === 'y') {
-        return true;
-      } else if (val === 'y/N' || val.toLowerCase() === 'n') {
-        return false;
-      }
-
-      return val;
-    };
-  }
-
-  return prompt;
-}
-
-// Monkey-patching prompt._performValidation to get rid of the overly verbose
-// error message.
-//
-// Arguments:
-// - name {Object} Variable name
-// - prop {Object|string} Variable to get input for.
-// - against {Object} Input
-// - schema {Object} Validation schema
-// - line {String|Boolean} Input line
-// - callback {function} Continuation to pass control to when complete.
-//
-// Perfoms user input validation, print errors if needed and returns value
-// according to validation
-//
-prompt_._performValidation = function (name, prop, against, schema, line, callback) {
-  var numericInput, valid, msg;
-
-  try {
-    valid = validate(against, schema);
-  } catch (err) {
-    return (line !== -1) ? callback(err) : false;
-  }
-
-  if (!valid.valid) {
-    msg = 'Invalid input';
-
-    if (prompt_.colors) {
-      prompt_.logger.error(msg);
-    } else {
-      prompt_.logger.error(msg);
-    }
-
-    if (prop.schema.message) {
-      prompt_.logger.error(prop.schema.message);
-    }
-
-    prompt_.emit('invalid', prop, line);
-  }
-
-  return valid.valid;
-};
+var inquirer = require("inquirer");
 
 // Prompt for user input based on the given Array of `prompts` to perform in
-// series, and call `done` callback on completion.  `prompts` can be a single
-// Hash of options in which case a single prompt is performed.
+// series, and call `done` callback on completion.
 //
-// Options can be any prompt's option: https://npmjs.org/package/prompt
+// Options can be any prompt's option: https://github.com/SBoudrias/Inquirer.js
 //
-// - prompts    - A single or an Array of Hash options.
+// - prompts    - an Array of Hash options.
 // - done       - Callback to call on error or on completion.
 //
 // Returns the generator instance.
-module.exports = function prompt(prompts, done) {
-  prompts = Array.isArray(prompts) ? prompts : [prompts];
-
-  prompts = prompts.map(evaluatePrompts);
-
-  prompt_.colors = false;
-  prompt_.message = '[' + '?'.green + ']';
-  prompt_.delimiter = ' ';
-  prompt_.start();
-
-  var results = {};
-  (function next(prompt) {
-    function handleResult(err, value) {
-      if (err) {
-        return done(err);
-      }
-
-      results[prompt.name] = value[prompt.name];
-      next(prompts.shift());
-    }
-
-    if (!prompt) {
-      return done(null, results);
-    }
-
-    prompt_.get(prompt, handleResult);
-  })(prompts.shift());
-
+module.exports = function prompt() {
+  inquirer.prompt.apply(inquirer, arguments);
   return this;
 };

--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -51,11 +51,7 @@ conflicter.resolve = function resolve(cb) {
       return cb();
     }
 
-    conflicter.collision(conflict.file, conflict.content, function (err, status) {
-      if (err) {
-        return cb(err);
-      }
-
+    conflicter.collision(conflict.file, conflict.content, function (status) {
       conflicter.emit('resolved:' + conflict.file, status);
       next(conflicts.shift());
     });
@@ -68,67 +64,58 @@ conflicter._ask = function (filepath, content, cb) {
   // the additional "Are you sure?" prompt
 
   var self = this;
-  var menu = [
-    ' ' + 'Y'.bold + '    yes         overwrite',
-    ' ' + 'n'.bold + '    no          do not overwrite',
-    ' ' + 'a'.bold + '    all         overwrite this and all others',
-    ' ' + 'q'.bold + '    quit        abort',
-    ' ' + 'd'.bold + '    diff        show the differences between the old and the new',
-    ' ' + 'h'.bold + '    help        show help'
-  ].join('\n');
 
-  var config = {
-    message: ('Overwrite ' + filepath + '? (enter "h" for help) [Ynaqdh]?'),
-    name: 'overwrite',
-    default: 'h'
-  };
+  var config = [{
+    type: "rawlist",
+    message: ('Overwrite ' + filepath + '?'),
+    choices: [
+      {
+        name: "Overwrite",
+        value: function () {
+          log.force(filepath);
+          return cb('force');
+        }
+      },
+      {
+        name: "do not overwrite",
+        value: function () {
+          log.skip(filepath);
+          return cb('skip');
+        }
+      },
+      {
+        name: "overwrite this and all others",
+        value: function () {
+          log.force(filepath);
+          self.force = true;
+          return cb('force');
+        }
+      },
+      {
+        name: "abort",
+        value: function () {
+          log.writeln('Aborting...');
+          return process.exit(0);
+        }
+      },
+      {
+        name: "show the differences between the old and the new",
+        value: function () {
+          console.log(conflicter.diff(fs.readFileSync(filepath, 'utf8'), content));
+          return self._ask(filepath, content, cb);
+        }
+      }
+    ],
+    name: 'overwrite'
+  }];
 
   process.nextTick(function () {
     self.emit('prompt', config);
     self.emit('conflict', filepath);
   });
 
-  prompt(config, function (err, result) {
-    if (err) {
-      return cb(err);
-    }
-
-    var answer = result.overwrite;
-
-    var ok = 'Yynaqdh'.split('').some(function (valid) {
-      return valid === answer;
-    });
-
-    if (answer === 'h' || !ok) {
-      console.log(menu);
-      return self._ask(filepath, content, cb);
-    }
-
-    if (answer === 'n') {
-      log.skip(filepath);
-      return cb(null, 'skip');
-    }
-
-    if (answer === 'q') {
-      log.writeln('Aborting...');
-      return process.exit(0);
-    }
-
-    if (/Y|a/i.test(answer)) {
-      log.force(filepath);
-      if (answer === 'a') {
-        self.force = true;
-      }
-      return cb(null, 'force');
-    }
-
-    if (answer === 'd') {
-      console.log(conflicter.diff(fs.readFileSync(filepath, 'utf8'), content));
-      return self._ask(filepath, content, cb);
-    }
-
-    // default, even though we should have handled every possible value
-    return cb();
+  prompt(config, function (result) {
+    cb(result.overwrite());
   });
 };
 
@@ -137,7 +124,7 @@ conflicter.collision = function collision(filepath, content, cb) {
 
   if (!fs.existsSync(filepath)) {
     log.create(filepath);
-    return cb(null, 'create');
+    return cb('create');
   }
 
   // TODO(mklabs): handle non utf8 file (images, etc.) and compare mtime instead,
@@ -145,12 +132,12 @@ conflicter.collision = function collision(filepath, content, cb) {
   var actual = fs.readFileSync(path.resolve(filepath), 'utf8');
   if (actual === content) {
     log.identical(filepath);
-    return cb(null, 'identical');
+    return cb('identical');
   }
 
   if (self.force) {
     log.force(filepath);
-    return cb(null, 'force');
+    return cb('force');
   }
 
   log.conflict(filepath);

--- a/package.json
+++ b/package.json
@@ -39,10 +39,9 @@
     "cli-table": "~0.2.0",
     "debug": "~0.7.2",
     "isbinaryfile": "~0.1.8",
-    "prompt": "~0.2.9",
-    "revalidator": "~0.1.5",
     "dargs": "~0.1.0",
-    "async": "~0.2.8"
+    "async": "~0.2.8",
+    "inquirer": "~0.1.3"
   },
   "devDependencies": {
     "mocha": "~1.9.0",

--- a/test/actions.js
+++ b/test/actions.js
@@ -32,7 +32,9 @@ describe('yeoman.generators.Base', function () {
   });
 
   it('generator.prompt(defaults, prompts, cb)', function (done) {
-    this.dummy.prompt([], done);
+    this.dummy.prompt([], function () {
+      done();
+    });
   });
 
   describe('generator.sourceRoot(root)', function () {

--- a/test/conflicter.js
+++ b/test/conflicter.js
@@ -54,21 +54,21 @@ describe('conflicter', function () {
   describe.skip('conflicter#collision(filepath, content, cb)', function (done) {
     var me = fs.readFileSync(__filename, 'utf8');
     it('identical status', function(done) {
-      conflicter.collision(__filename, me, function (err, status) {
+      conflicter.collision(__filename, me, function (status) {
         assert.equal(status, 'identical');
         done();
       });
     });
 
     it('create status', function (done) {
-      conflicter.collision('foo.js', '', function (err, status) {
+      conflicter.collision('foo.js', '', function (status) {
         assert.equal(status, 'create');
         done();
       });
     });
 
     it('conflict status', function (done) {
-      conflicter.collision(__filename, '', function (err, status) {
+      conflicter.collision(__filename, '', function (status) {
         assert.equal(status, 'force');
         done();
       });
@@ -83,7 +83,7 @@ describe('conflicter', function () {
   describe('conflicter#_ask', function () {
     var promptMock = {
       prompt: function (config, cb) {
-        cb(this.err, { overwrite: this.answer });
+        cb({ overwrite: this.answer });
       },
       err: null,
       answer: null
@@ -95,23 +95,13 @@ describe('conflicter', function () {
       });
     });
 
-    it('skips on "n answer"', function (done) {
-      promptMock.answer = 'n';
-      this.conflicter._ask('/tmp/file', 'my file contents', function (err, result) {
-        assert.strictEqual(err, null);
-        assert(result, 'skip');
+    it('Calls answer related function', function (done) {
+      var callCount = 0;
+      promptMock.answer = function () { callCount++; };
+      this.conflicter._ask('/tmp/file', 'my file contents', function (result) {
+        assert(callCount, 1);
         done();
       });
-    });
-
-    it('enables force on "a" answer', function (done) {
-      promptMock.answer = 'a';
-      this.conflicter._ask('/tmp/file', 'my file contents', function (err, result) {
-        assert.strictEqual(err, null);
-        assert(result, 'force');
-        assert(this.conflicter.force);
-        done();
-      }.bind(this));
     });
   });
 });


### PR DESCRIPTION
That's a PR following #228 discussion.

So, I created a separated module to handle prompt types ([Inquirer](https://github.com/SBoudrias/Inquirer.js)) with some option to validate and filter the user input. It is based upon Readline node API, so this allow realtime CLI update and acting on keypress events.

Right now, it is implemented in the beta [BBB generator](https://github.com/backbone-boilerplate/generator-bbb) and it's working great over there.

Feel free to discuss if you feel any features went missing or would be great add-on.

---

_I didn't take time to completly remove the old prompt system. I guess this should be done in the future or before merging this one._
