### PR TITLE
Added a callback to `installDependencies`

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -1,5 +1,6 @@
 var _ = require('lodash');
 var dargs = require('dargs');
+var async = require('async');
 
 var install = module.exports;
 
@@ -53,44 +54,59 @@ install.runInstall = function (installer, paths, options, cb) {
 //   this.installDependencies({
 //      bower: true,
 //      npm: true,
-//      skipInstall: false
+//      skipInstall: false,
+//      callback: function () {
+//         console.log('Everything is ready!');
+//      }
 //   });
 //
 // Returns the generator instance.
 install.installDependencies = function (options) {
-  var commands = [];
-  var msgTemplate = _.template('\n\nI\'m all done. ' +
+  var msg = {
+    commands: [],
+    template: _.template('\n\nI\'m all done. ' +
     '<%= skipInstall ? "Just run" : "Running" %> <%= commands.bold.yellow %> ' +
     '<%= skipInstall ? "" : "for you " %>to install the required dependencies.' +
-    '<% if (!skipInstall) { %> If this fails, try running the command yourself.<% } %>\n\n');
+    '<% if (!skipInstall) { %> If this fails, try running the command yourself.<% } %>\n\n')
+  };
+
+  var commands = [];
+
+  if (_.isFunction(options)) {
+    options = {
+      callback: options
+    };
+  }
 
   options = _.defaults(options || {}, {
     bower: true,
     npm: true,
-    skipInstall: false
+    skipInstall: false,
+    callback: function () {}
   });
 
   if (options.bower) {
-    commands.push('bower install');
+    msg.commands.push('bower install');
+    commands.push(function (cb) {
+      this.bowerInstall(null, null, cb);
+    }.bind(this));
   }
 
   if (options.npm) {
-    commands.push('npm install');
+    msg.commands.push('npm install');
+    commands.push(function (cb) {
+      this.npmInstall(null, null, cb);
+    }.bind(this));
   }
 
-  if (commands.length === 0) {
+  if (msg.commands.length === 0) {
     throw new Error('installDependencies needs at least one of npm or bower to run.');
   }
 
-  console.log(msgTemplate(_.extend(options, { commands: commands.join(' & ') })));
+  console.log(msg.template(_.extend(options, { commands: msg.commands.join(' & ') })));
 
   if (!options.skipInstall) {
-    if (options.bower) {
-      this.bowerInstall();
-    }
-    if (options.npm) {
-      this.npmInstall();
-    }
+    async.parallel(commands, options.callback);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "isbinaryfile": "~0.1.8",
     "prompt": "~0.2.9",
     "revalidator": "~0.1.5",
-    "dargs": "~0.1.0"
+    "dargs": "~0.1.0",
+    "async": "~0.2.8"
   },
   "devDependencies": {
     "mocha": "~1.9.0",

--- a/test/actions.js
+++ b/test/actions.js
@@ -258,6 +258,26 @@ describe('yeoman.generators.Base', function () {
         this.dummy.npmInstall('yo', { save: true });
         assert.deepEqual(this.commandsRun.length, 1);
       });
+
+      it('should execute a callback after installs', function () {
+        var called = false;
+        this.dummy.installDependencies({
+          callback: function () {
+            called = true;
+          }
+        });
+        assert.deepEqual(this.commandsRun, ['bower', 'npm']);
+        assert(called);
+      });
+
+      it('should accept and execute a function as its only argument', function () {
+        var called = false;
+        this.dummy.installDependencies(function () {
+          called = true;
+        });
+        assert.deepEqual(this.commandsRun, ['bower', 'npm']);
+        assert(called);
+      });
     });
   });
 });


### PR DESCRIPTION
I thought it would be helpful to add a callback after any installed dependencies finish processing. Currently when installing Bower & NPM deps, `this.installDependencies()` launches two concurrent processes. I added an object to track how many commands will execute, and after the last command is finished processing, it calls the callback passed into `this.installDependencies`.

My use case...

(If there is already a way to do this, let me know! :smile:)

I wanted to log out a message on how to use the generator after the dependencies were installed.

``` js
var WeblogGenerator = module.exports = function WeblogGenerator(args, options, config) {
  yeoman.generators.Base.apply(this, arguments);

  this.pkg = JSON.parse(this.readFileAsString(path.join(__dirname, '../package.json')));

  this.on('end', function () {
    var howTo
    = '\n'
    + '\nSweet!'.yellow + ' You now have a very pretty blog!'
    + '\n-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-'.red
    + '\n'
    + '\n  To create a new post, run:'
    + '\n'
    + '\n    yo weblog:post'.cyan
    + '\n'
    + '\n  To see your changes as you make them, kick up a server:'
    + '\n'
    + '\n    grunt server'.cyan
    + '\n'
    + '\n  When you\'re ready to publish your blog, run:'
    + '\n'
    + '\n    grunt build'.cyan;

    this.installDependencies({
      callback: function (res) {
        if (!res) {
          return;
        }

        console.log(howTo);
      }
    });
});
```

I also added in support for simply passing the callback to `installDependencies`:

``` js
this.installDependencies(function (res) {
  if (!res) {
    return;
  }

  console.log(howTo);
});
```

If I did anything silly, please let me know!
