### PR TITLE
Remove the forced LF line ending in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 [*]
 indent_style = space
 indent_size = 2
-end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true


### PR DESCRIPTION
Forcing LF via `.editorconfig` is super annoying when working on Windows. The line ending normalization in the repo is already forced by `.gitattributes`, the editorconfig one just completely break the git diff for Windows user and it forces us to resave file each time we open it up (as Git will checkout RN on windows). So I'd vote to remove it - please!
