### PR TITLE
Fix Windows generator namespacing (#254)

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -574,17 +574,19 @@ Environment.prototype.namespace = function namespace(filepath) {
     throw new Error('Missing namespace');
   }
 
+  var self = this;
+
   // cleanup extension
   var ns = filepath.replace(path.extname(filepath), '');
 
   // cleanup lookup path
   ns = this.lookups.reduce(function (ns, lookup) {
-    return ns.replace(lookup, '');
+    return ns.replace(self.regexizePath(lookup), '');
   }, ns);
 
   // cleanup prefix paths
   ns = this.paths.reduce(function (ns, filepath) {
-    return ns.replace(path.resolve(filepath), '');
+    return ns.replace(self.regexizePath(path.resolve(filepath)), '');
   }, ns);
 
   ns = ns
@@ -708,4 +710,14 @@ Environment.prototype.remote = function remote(name, done) {
     .write(self.help()).write();
     done();
   });
+};
+
+// Take a path and return a normalized regexp to match the path in different OS
+//
+// - path - file system path string
+//
+// Returns a normalized regexp
+Environment.prototype.regexizePath = function regexizePath(path) {
+  var pattern = path.replace(/[\/\\]/g, '[\\/\\\\]');
+  return new RegExp(pattern);
 };

--- a/test/env.js
+++ b/test/env.js
@@ -141,6 +141,21 @@ describe('Environment', function () {
       var mocha = env.create('fixtures:mocha-generator');
       mocha.run(done);
     });
+
+    it('can normalize paths to cross-OS regexp', function() {
+      var regexizePath = generators().regexizePath;
+      assert.equal(typeof regexizePath, "function");
+
+      // can normalize Unix path
+      var regex = regexizePath("/foo/bar");
+      assert.ok(regex.test("/foo/bar"));
+      assert.ok(regex.test("\\foo\\bar"));
+
+      // can normalize Windows path
+      var regex2 = regexizePath("\\foo\\bar");
+      assert.ok(regex2.test("/foo/bar"));
+      assert.ok(regex2.test("\\foo\\bar"));
+    });
   });
 
   describe('Engines', function() {


### PR DESCRIPTION
That should fix issue #254. Problem was that calling replace with an un-normalized path (a classic `\` and `/` issue) wasn't working.
