### PR TITLE
Fix regexizePath so it escape '.' character

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -718,6 +718,6 @@ Environment.prototype.remote = function remote(name, done) {
 //
 // Returns a normalized regexp
 Environment.prototype.regexizePath = function regexizePath(path) {
-  var pattern = path.replace(/[\/\\]/g, '[\\/\\\\]');
+  var pattern = path.replace(/[\/\\]/g, '[\\/\\\\]').replace(".", "\\.");
   return new RegExp(pattern);
 };


### PR DESCRIPTION
Fix failing unit test in #255 and fix the real bug introduced.
