### PR TITLE
Refactor env.namespace

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -576,30 +576,34 @@ Environment.prototype.namespace = function namespace(filepath) {
 
   var self = this;
 
-  // cleanup extension
-  var ns = filepath.replace(path.extname(filepath), '');
+  // cleanup extension and normalize path for differents OS
+  var ns = path.normalize(filepath.replace(path.extname(filepath), ''));
 
-  // cleanup lookup path
-  ns = this.lookups.reduce(function (ns, lookup) {
-    return ns.replace(self.regexizePath(lookup), '');
+  // Extend every lookups folders with searchable file system paths
+  var lookups = _(this.lookups).map(function (lookup) {
+    return _.map(self.paths, function (filepath) {
+      return path.join(filepath, lookup);
+    });
+  }).flatten().sortBy('length').value().reverse();
+
+  // If `ns` contain a lookup dir in it's path, remove it.
+  ns = lookups.reduce(function (ns, lookup) {
+    return ns.replace(lookup, '');
   }, ns);
 
-  // cleanup prefix paths
-  ns = this.paths.reduce(function (ns, filepath) {
-    return ns.replace(self.regexizePath(path.resolve(filepath)), '');
-  }, ns);
-
+  // Cleanup `ns` from unwanted parts and then normalize slashes to `:`
   ns = ns
-    .replace(/[\/\\]?node_modules\/?/, '')
-    .replace(/[\/\\](index|main)$/, '')
-    .replace(/\.+[\/\\]?/g, '')
-    .replace(/[\/\\]+/g, ':');
+    .replace(/[\/\\]?node_modules[\/\\]?/, '') // remove `/node_modules/`
+    .replace(/[\/\\](index|main)$/, '') // remove `/index` or `/main`
+    .replace(/\.+/g, '') // remove `.`
+    .replace(/^[\/\\]+/, '') // remove leading `/`
+    .replace(/[\/\\]+/g, ':'); // replace slashes by `:`
 
   // if we still have prefix match at this point, then remove anything before
   // that match, this would catch symlinked package with a name begining with
   // `generator-*` (one of the configured prefix)
   ns = this._prefixes.reduce(function (ns, prefix) {
-    var pos = ns.indexOf(prefix);
+    var pos = ns.lastIndexOf(prefix);
 
     if (pos < 0) {
       return ns;
@@ -610,8 +614,7 @@ Environment.prototype.namespace = function namespace(filepath) {
 
   debug('Resolve namespaces for %s: %s', filepath, ns);
 
-  // ensure we prevent subsequent namespaces from showing
-  return _.uniq(ns.split(':')).join(':').replace(/^:/, '');
+  return ns;
 };
 
 
@@ -710,14 +713,4 @@ Environment.prototype.remote = function remote(name, done) {
     .write(self.help()).write();
     done();
   });
-};
-
-// Take a path and return a normalized regexp to match the path in different OS
-//
-// - path - file system path string
-//
-// Returns a normalized regexp
-Environment.prototype.regexizePath = function regexizePath(path) {
-  var pattern = path.replace(/[\/\\]/g, '[\\/\\\\]').replace(".", "\\.");
-  return new RegExp(pattern);
 };

--- a/test/env.js
+++ b/test/env.js
@@ -141,21 +141,6 @@ describe('Environment', function () {
       var mocha = env.create('fixtures:mocha-generator');
       mocha.run(done);
     });
-
-    it('can normalize paths to cross-OS regexp', function () {
-      var regexizePath = generators().regexizePath;
-      assert.equal(typeof regexizePath, 'function');
-
-      // can normalize Unix path
-      var regex = regexizePath('/foo/bar');
-      assert.ok(regex.test('/foo/bar'));
-      assert.ok(regex.test('\\foo\\bar'));
-
-      // can normalize Windows path
-      var regex2 = regexizePath('\\foo\\bar');
-      assert.ok(regex2.test('/foo/bar'));
-      assert.ok(regex2.test('\\foo\\bar'));
-    });
   });
 
   describe('Engines', function () {

--- a/test/namespaces.js
+++ b/test/namespaces.js
@@ -23,4 +23,30 @@ describe('Alias and namespaces', function () {
     assert.equal(env.namespace('././local/stuff'), 'local:stuff');
     assert.equal(env.namespace('../../local/stuff'), 'local:stuff');
   });
+
+  it('should work with mixed similar lookups', function () {
+    var env = generators();
+
+    // Order is important, smaller lookup must come first here
+    env.appendLookup('foo');
+    env.appendLookup('foo/bar');
+
+    assert.equal(env.namespace('foo/gen/all'), 'gen:all');
+    assert.equal(env.namespace('foo/bar/gen/all'), 'gen:all');
+  });
+
+  it('should work with weird paths', function () {
+    var env = generators();
+    assert.equal(env.namespace('////gen/all'), 'gen:all');
+    assert.equal(env.namespace('generator-backbone///all.js'), 'backbone:all');
+    assert.equal(env.namespace('generator-backbone/././all.js'), 'backbone:all');
+    assert.equal(env.namespace('generator-backbone/generator-backbone/all.js'), 'backbone:all');
+  });
+
+  it('should work in different OS', function () {
+    var env = generators();
+    assert.equal(env.namespace('backbone\\all\\main.js'), 'backbone:all');
+    assert.equal(env.namespace('backbone\\all'), 'backbone:all');
+    assert.equal(env.namespace('backbone\\all.js'), 'backbone:all');
+  });
 });


### PR DESCRIPTION
I tried to solidify the logic inside `env.namespace`. The biggest change is that `lookups` and `paths` cleanup is done all at once, so this should prevent some trouble if path repeats itself. 

Also, the path normalization is done upfront, so this prevent us from having to put much logic in differentiating Windows from Unix system (exception made of the regexp).

And lastly, the lookups dir to removed is now ordered, so this will prevent conflict like what would happen with issue #212.

Let me know if you see anything that could be simplified.
