### PR TITLE
remove unnecessary argument.

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -239,13 +239,13 @@ Base.prototype.run = function run(args, cb) {
     var rules = {
       underscore: method.charAt(0) !== '_',
       initialize: !/^(constructor|initialize)$/.test(method),
-      isValid: function () {
+      valid: function () {
         return this.underscore && this.initialize;
       }
     };
 
     return function (next) {
-      if (!rules.isValid(method)) {
+      if (!rules.valid()) {
         return next();
       }
 


### PR DESCRIPTION
While I was playing with the different ways to validate a method name, I forgot to remove this needless argument to the `isValid` function. While I was at it, `rules.isValid` didn't read as well as `rules.valid`, so I made a little switch-a-roo!
