### PR TITLE
use async in runHooks.

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -284,29 +284,23 @@ Base.prototype.runHooks = function runHooks(cb) {
   var self = this;
   var hooks = this._hooks;
 
-  (function next(hook) {
-    if (!hook) {
-      process.nextTick(function () {
-        self.emit('end');
-        cb();
-      });
-      return;
-    }
+  var callback = function (err) {
+    self.emit('end');
+    cb(err);
+  };
 
+  var resolve = function (hook) {
     var resolved = self.defaultFor(hook.name);
-    var options = hook.options || self.options;
     var context = hook.as || self.resolved || self.generateName;
+    var options = hook.options || self.options;
     options.args = hook.args || self.args;
 
-    self.invoke(resolved + (context ? ':' + context : ''), options, function (err) {
-      if (err) {
-        return cb(err);
-      }
+    return function (next) {
+      self.invoke(resolved + (context ? ':' + context : ''), options, next);
+    };
+  };
 
-      next(hooks.shift());
-    });
-
-  }(hooks.shift()));
+  async.series(hooks.map(resolve), callback);
 
   return this;
 };


### PR DESCRIPTION
I'm just going through and popping the async module in more spots. The next function on the list after `Base.prototype.run` was `Base.prototype.runHooks` :)
