### PR TITLE
base/run async conflicter resolved.

### DIFF
--- a/lib/actions/actions.js
+++ b/lib/actions/actions.js
@@ -7,6 +7,7 @@ var events = require('events');
 var mkdirp = require('mkdirp');
 var isBinaryFile = require('isbinaryfile');
 var rimraf = require('rimraf');
+var async = require('async');
 
 var actions = module.exports;
 
@@ -216,23 +217,27 @@ actions.engine = function engine(body, data) {
 // Returns the generator instance
 actions.directory = function directory(source, destination) {
   var root = path.join(this.sourceRoot(), source);
-  var list = this.expandFiles('**', { dot: true, cwd: root });
+  var files = this.expandFiles('**', { dot: true, cwd: root });
   var self = this;
 
   destination = destination || source;
 
   // get the path relative to the template root, and copy to the relative destination
-  (function next(filepath) {
-    if (!filepath) {
-      self.emit('directory:end');
-      return;
-    }
+  var resolveFiles = function (filepath) {
+    return function (next) {
+      if (!filepath) {
+        self.emit('directory:end');
+        return next();
+      }
 
-    var dest = path.join(destination, filepath);
-    self.copy(path.join(root, filepath), dest);
+      var dest = path.join(destination, filepath);
+      self.copy(path.join(root, filepath), dest);
 
-    return next(list.shift());
-  })(list.shift());
+      return next();
+    };
+  };
+
+  async.parallel(files.map(resolveFiles));
 
   return this;
 };

--- a/lib/base.js
+++ b/lib/base.js
@@ -249,23 +249,26 @@ Base.prototype.run = function run(args, cb) {
         return next();
       }
 
+      var done = function () {
+        self.conflicter.resolve(function (err) {
+          if (err) {
+            return self.emit('error', err);
+          }
+        });
+        next();
+      };
+
       self.async = function () {
         self.async.running = true;
-        return next;
+        return done;
       };
 
       self.emit(method);
       self.emit('method', method);
       self[method].apply(self, args);
 
-      conflicter.resolve(function (err) {
-        if (err) {
-          return self.emit('error', err);
-        }
-      });
-
       if (!self.async.running) {
-        next();
+        done();
       }
     };
   };


### PR DESCRIPTION
Fixes #269

``` js
self.conflicter.resolve(function (err) {
  if (err) {
    return self.emit('error', err);
  }
});
```

That block was called from base.js/run before giving the files a chance to be added to the conflicter. Thus, callbacks bound to the `resolved:___` event weren't firing, and everything was locking up.
