### PR TITLE
Mocha generator should point to the right place

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ The docs cover how to create generators from scratch as well as recommending com
 
 ## Testing generators
 
-There is currently no formal infrastructure for testing generators, however you may find our [mocha generator](https://github.com/yeoman/yeoman/wiki/Testing-generators) for custom generators useful.
+There is currently no formal infrastructure for testing generators, however you may find our [mocha generator](https://github.com/yeoman/generator-mocha) for custom generators useful.
 
 ## Officially maintained generators
 


### PR DESCRIPTION
Link was pointing to generator testing instead of mocha testing
