### PR TITLE
fixes #233 - template race condition.

### DIFF
--- a/lib/actions/actions.js
+++ b/lib/actions/actions.js
@@ -77,17 +77,18 @@ actions.copy = function copy(source, destination) {
     body = fs.readFileSync(source, encoding);
   }
 
-  this.checkForCollision(destination, body, function (err, status) {
+  this.checkForCollision(destination, body, function (err, config) {
     var stats;
 
     if (err) {
+      config.callback(err);
       return this.emit('error', err);
     }
 
     // Create or force means file write, identical or skip prevent the
     // actual write
-    if (!(/force|create/.test(status))) {
-      return;
+    if (!(/force|create/.test(config.status))) {
+      return config.callback();
     }
 
     mkdirp.sync(path.dirname(destination));
@@ -101,6 +102,8 @@ actions.copy = function copy(source, destination) {
     } catch (err) {
       this.log.error('Error setting permissions of "' + destination.bold + '" file: ' + err);
     }
+
+    config.callback();
   }.bind(this));
 
   return this;
@@ -133,17 +136,20 @@ actions.read = function read(source, encoding) {
 //
 // Returns the generator instance
 actions.write = function write(filepath, content) {
-  this.checkForCollision(filepath, content, function (err, status) {
+  this.checkForCollision(filepath, content, function (err, config) {
     if (err) {
+      config.callback(err);
       return this.emit('error', err);
     }
 
     // create or force means file write, identical or skip prevent the
     // actual write
-    if (/force|create/.test(status)) {
+    if (/force|create/.test(config.status)) {
       mkdirp.sync(path.dirname(filepath));
       fs.writeFileSync(filepath, content);
     }
+
+    config.callback();
   });
   return this;
 };

--- a/lib/base.js
+++ b/lib/base.js
@@ -254,8 +254,9 @@ Base.prototype.run = function run(args, cb) {
           if (err) {
             return self.emit('error', err);
           }
+
+          next();
         });
-        next();
       };
 
       var running = false;

--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -6,6 +6,7 @@ var events = require('events');
 var diff = require('diff');
 var prompt = require('../actions/prompt');
 var log = logger('conflicter');
+var async = require('async');
 
 var conflicter = module.exports = Object.create(events.EventEmitter.prototype);
 
@@ -45,18 +46,30 @@ conflicter.shift = function shift() {
 };
 
 conflicter.resolve = function resolve(cb) {
-  var conflicts = this.conflicts;
-  (function next(conflict) {
-    if (!conflict) {
-      return cb();
+  var resolveConflicts = function (conflict) {
+    return function (next) {
+      if (!conflict) {
+        return next();
+      }
+
+      conflicter.collision(conflict.file, conflict.content, function (status) {
+        conflicter.emit('resolved:' + conflict.file, {
+          status: status,
+          callback: next
+        });
+      });
+    };
+  };
+
+  async.series(this.conflicts.map(resolveConflicts), function (err) {
+    if (err) {
+      cb();
+      return self.emit('error', err);
     }
 
-    conflicter.collision(conflict.file, conflict.content, function (status) {
-      conflicter.emit('resolved:' + conflict.file, status);
-      next(conflicts.shift());
-    });
-
-  })(conflicts.shift());
+    conflicter.reset();
+    cb();
+  }.bind(this));
 };
 
 conflicter._ask = function (filepath, content, cb) {
@@ -66,42 +79,40 @@ conflicter._ask = function (filepath, content, cb) {
   var self = this;
 
   var config = [{
-    type: 'rawlist',
+    type: 'list',
     message: 'Overwrite ' + filepath + '?',
-    choices: [
-      {
-        name: 'Overwrite',
-        value: function () {
-          log.force(filepath);
-          return cb('force');
-        }
-      }, {
-        name: 'do not overwrite',
-        value: function () {
-          log.skip(filepath);
-          return cb('skip');
-        }
-      }, {
-        name: 'overwrite this and all others',
-        value: function () {
-          log.force(filepath);
-          self.force = true;
-          return cb('force');
-        }
-      }, {
-        name: 'abort',
-        value: function () {
-          log.writeln('Aborting ...');
-          return process.exit(0);
-        }
-      }, {
-        name: 'show the differences between the old and the new',
-        value: function () {
-          console.log(conflicter.diff(fs.readFileSync(filepath, 'utf8'), content));
-          return self._ask(filepath, content, cb);
-        }
+    choices: [{
+      name: 'Overwrite',
+      value: function () {
+        log.force(filepath);
+        return cb('force');
       }
-    ],
+    }, {
+      name: 'do not overwrite',
+      value: function () {
+        log.skip(filepath);
+        return cb('skip');
+      }
+    }, {
+      name: 'overwrite this and all others',
+      value: function () {
+        log.force(filepath);
+        self.force = true;
+        return cb('force');
+      }
+    }, {
+      name: 'abort',
+      value: function () {
+        log.writeln('Aborting ...');
+        return process.exit(0);
+      }
+    }, {
+      name: 'show the differences between the old and the new',
+      value: function () {
+        console.log(conflicter.diff(fs.readFileSync(filepath, 'utf8'), content));
+        return self._ask(filepath, content, cb);
+      }
+    }],
     name: 'overwrite'
   }];
 

--- a/test/conflicter.js
+++ b/test/conflicter.js
@@ -39,14 +39,58 @@ describe('conflicter', function () {
       conflicter.resolve(done);
     });
 
-    it('with at least one', function (done) {
+    it('with at least one, without async callback handling', function (done) {
+      var conflicts = 0;
+      var callbackExecuted = false;
+
       conflicter.add(__filename);
       conflicter.add({
         file: 'foo.js',
         content: 'var foo = "foo";\n'
       });
 
-      conflicter.resolve(done);
+      // called.
+      conflicter.once('resolved:' + __filename, function (config) {
+        conflicts++;
+      });
+
+      // not called.
+      conflicter.once('resolved:foo.js', function (config) {
+        conflicts++;
+      });
+
+      conflicter.resolve(function(){
+        callbackExecuted = true;
+      });
+
+      assert(conflicts, 1);
+      assert(!callbackExecuted);
+      done();
+    });
+
+    it('with at least one, with async callback handling', function (done) {
+      var called = 0;
+
+      conflicter.add(__filename);
+      conflicter.add({
+        file: 'foo.js',
+        content: 'var foo = "foo";\n'
+      });
+
+      conflicter.once('resolved:' + __filename, function (config) {
+        called++;
+        config.callback();
+      });
+
+      conflicter.once('resolved:foo.js', function (config) {
+        called++;
+        config.callback();
+      });
+
+      conflicter.resolve(function(){
+        assert(called, 2);
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
(#233)

Life is good again.

I didn't realize this was an issue, so I'm sorry I've just been adding to the problem rather than working towards fixing it. However, this fixes things!

`actions.js:write()` and `actions.js:copy()` are the only two functions which call `actions.js:checkForCollision()`, which is the only place a listener is set up for the `resolved:*filename*` event. When the `resolved:*filename*` event is triggered, the callback passed into `actions.js:checkForCollision()` is executed. And guess what's in that callback? The `next` async function from `conflicter.js:resolve()`. After all of these `conflicter.collisions` are resolved that the final `next` will eventually be called, which then fires off the callback from the async process, which gives control back to `base.js:run()`, so the generator's prototype methods continue executing as usual.

I'll try explaining another way, since ^ was nuts.
- base.js
  - run()
    - finds a method that says `var blah = this.async()`
    - waits for `blah` to be called
- custom generator's index.js
  - someMethod()
    - says `var blah = this.async()`
    - calls `this.directory()`
- actions.js
  - executes `this.directory()`
  - executes `this.copy()`
  - executes `this.checkForCollision(callback)`
    - binds `callback` on the conflicter's `resolved:*filename*` event
- custom generator's index.js
  - ~~someMethod()~~
    - ~~says `var blah = this.async()`~~
    - ~~calls `this.directory()`~~
    - calls `blah()`
- base.js
  - run()
    - `blah()` now calls `conflicter.resolve`, passing a callback that when called will continue the execution of the rest of the generator's methods
- conflicter.js
  - resolve(callback)
    - was just called with a callback from `base.js:run`
    - uses `async.series` to go through each conflicted file
      - resolves each file
      - emits a `resolved` event with a new argument; an object containing the `next` async callback
- actions.js
  - calls the callback that is bound to the `resolved:*filename*` event, which was passed into `actions.js -> checkForCollision()`
    - among other things, this will call the original `next()` from `base.js -> run()`, which will enable the execution of the generator's methods to continue

Ok, there's clearly no good way to explain this. It works, I swear! :deciduous_tree: 
