### PR TITLE
fixes #275 - mockPrompt() callback in sync with prompt().

### DIFF
--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -120,7 +120,7 @@ helpers.testDirectory = function (dir, cb) {
 helpers.mockPrompt = function (generator, answers) {
   var origPrompt = generator.prompt;
   generator.prompt = function (prompts, done) {
-    done(null, answers);
+    done(answers);
   };
   generator.origPrompt = origPrompt;
 };


### PR DESCRIPTION
Removed from the `null` from the `helper.mockPrompt`.
