### PR TITLE
add common generator helpers.

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -88,6 +88,7 @@ _.extend(Base.prototype, require('./actions/file'));
 _.extend(Base.prototype, require('./actions/install'));
 _.extend(Base.prototype, require('./actions/string'));
 _.extend(Base.prototype, require('./actions/wiring'));
+_.extend(Base.prototype, require('./util/common'));
 Base.prototype.prompt = require('./actions/prompt');
 Base.prototype.invoke = require('./actions/invoke');
 Base.prototype.spawnCommand = require('./actions/spawn_command');

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -1,0 +1,10 @@
+module.exports.yeoman =
+'\n     _-----_' +
+'\n    |       |' +
+'\n    |' + '--(o)--'.red + '|   .--------------------------.' +
+'\n   `---------´  |    ' + 'Welcome to Yeoman,'.yellow.bold + '    |' +
+'\n    ' + '( '.yellow + '_' + '´U`'.yellow + '_' + ' )'.yellow + '   |   ' + 'ladies and gentlemen!'.yellow.bold + '  |' +
+'\n    /___A___\\   \'__________________________\'' +
+'\n     |  ~  |'.yellow +
+'\n   __' + '\'.___.\''.yellow + '__' +
+'\n ´   ' + '`  |'.red + '° ' + '´ Y'.red + ' `\n';


### PR DESCRIPTION
This is kind of a flaky idea, but thought it could get some feedback.

Instead of every generator defining:

```
var guy = '\n     _-----_' +
'\n    |       |' +
'\n    |' + '--(o)--'.red + '|   .--------------------------.' +
'\n   `---------´  |    ' + 'Welcome to Yeoman,'.yellow.bold + '    |' +
'\n    ' + '( '.yellow + '_' + '´U`'.yellow + '_' + ' )'.yellow + '   |   ' + 'ladies and gentlemen!'.yellow.bold + '  |' +
'\n    /___A___\\   \'__________________________\'' +
'\n     |  ~  |'.yellow +
'\n   __' + '\'.___.\''.yellow + '__' +
'\n ´   ' + '`  |'.red + '° ' + '´ Y'.red + ' `\n';
```

I thought we could keep that within the generator itself, allowing them to access it with just `this.yeoman`. I created a special `lib/common.js` file for it, but couldn't immediately think of other similar common things that could go there.

Any ideas, or :bomb: this idea altogether?
