### PR TITLE
Correct signal that spawn() may emit

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -26,7 +26,7 @@ install.runInstall = function (installer, paths, options, cb) {
   var args = ['install'].concat(paths).concat(dargs(options));
 
   this.spawnCommand(installer, args, cb)
-    .on('err', cb)
+    .on('error', cb)
     .on('exit', this.emit.bind(this, installer + 'Install:end', paths))
     .on('exit', function (err) {
       if (err === 127) {


### PR DESCRIPTION
According to http://nodejs.org/api/child_process.html#child_process_event_error, the signal name is `error` and not `err`

With `err`, I was getting a `throw er; // Unhandled 'error' event` (when deleting `bower`, for example, for testing)

With `error` as signal, the error is correctly handled
