### PR TITLE
Error can be passed into async() + new helper method.

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -250,7 +250,12 @@ Base.prototype.run = function run(args, cb) {
         return next();
       }
 
-      var done = function () {
+      var done = function (err) {
+        if (err) {
+          self.emit('error', err);
+        }
+
+        // Resolve file conflicts after every method completes.
         self.conflicter.resolve(function (err) {
           if (err) {
             return self.emit('error', err);

--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -10,6 +10,8 @@ var generators = require('../..');
 // Mocha helpers
 var helpers = module.exports;
 
+helpers.stubs = [];
+
 // cleanup the test dir, and cd into it
 helpers.before = function before(dir) {
   if (!dir) {
@@ -28,6 +30,48 @@ helpers.before = function before(dir) {
       helpers.gruntfile({ dummy: true }, done);
     });
   };
+};
+
+// Wrap a method with custom functionality.
+//
+// - context     - (object) context to find the original method
+// - method      - (string) name of the method to wrap
+// - replacement - (function) executes before the original method
+// - options     - (opt) (object) config settings
+helpers.decorate = function decorate(context, method, replacement, options) {
+  options = options || {};
+
+  var naturalMethod = context[method];
+
+  helpers.stubs.push({
+    context: context,
+    method: method,
+    naturalMethod: naturalMethod
+  });
+
+  context[method] = function () {
+    replacement.apply(context, arguments);
+
+    if (!options.stub) {
+      naturalMethod.apply(context, arguments);
+    }
+  };
+};
+
+// Override a method with custom functionality.
+//
+// - context     - (object) context to find the original method
+// - method      - (string) name of the method to wrap
+// - replacement - (function) executes before the original method
+helpers.stub = function stub(context, method, replacement) {
+  helpers.decorate(context, method, replacement, { stub: true });
+};
+
+// Restore all stubs with original behavior.
+helpers.restore = function restore() {
+  helpers.stubs.forEach(function (stub) {
+    stub.context[stub.method] = stub.naturalMethod;
+  });
 };
 
 // Generates a new Gruntfile.js in the current working directory based on


### PR DESCRIPTION
RE: #289

Errors passed into `this.async()` are being ignored, currently. I matched the old functionality, wrote a couple of tests, and also added in a test helper. Let me know if this can or should be done differently!
