### PR TITLE
output correct usage message e.g. yo generator:sub-generator NAME

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -43,6 +43,7 @@ var Base = module.exports = function Base(args, options) {
   this.resolved = this.options.resolved;
   this.fallbacks = this.options.generators || this.options.generator || {};
   this.generatorName = this.options.name || '';
+  this.generatorFullName = this.options.argv.original[0];
 
   this.description = '';
 
@@ -449,13 +450,9 @@ Base.prototype.usage = function usage() {
     return arg.config.banner;
   }).join(' ');
 
-  var options = this._options.length ? '[options]' : '',
-    name = (this.namespace === 'yeoman:app' || !this.namespace) ? '' : this.namespace + ' ',
-    cmd = 'init';
+  var options = this._options.length ? '[options]' : '';
 
-  name = name.replace(/^yeoman:/, '');
-
-  var out = 'yeoman ' + cmd + ' ' + name + args + ' ' + options;
+  var out = 'yo ' + this.generatorFullName + ' ' + args + ' ' + options;
 
   if (this.description) {
     out += '\n\n' + this.description;


### PR DESCRIPTION
The syntax seems to be outdated.
