### PR TITLE
Update Inquirer to 0.2 (and change conflicter prompt)

### DIFF
--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -79,21 +79,24 @@ conflicter._ask = function (filepath, content, cb) {
   var self = this;
 
   var config = [{
-    type: 'list',
+    type: 'expand',
     message: 'Overwrite ' + filepath + '?',
     choices: [{
+      key: 'y',
       name: 'overwrite',
       value: function (cb) {
         log.force(filepath);
         return cb('force');
       }
     }, {
+      key: 'n',
       name: 'do not overwrite',
       value: function (cb) {
         log.skip(filepath);
         return cb('skip');
       }
     }, {
+      key: 'a',
       name: 'overwrite this and all others',
       value: function (cb) {
         log.force(filepath);
@@ -101,12 +104,14 @@ conflicter._ask = function (filepath, content, cb) {
         return cb('force');
       }
     }, {
+      key: 'x',
       name: 'abort',
       value: function (cb) {
         log.writeln('Aborting ...');
         return process.exit(0);
       }
     }, {
+      key: 'd',
       name: 'show the differences between the old and the new',
       value: function (cb) {
         console.log(conflicter.diff(fs.readFileSync(filepath, 'utf8'), content));

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "isbinaryfile": "~0.1.8",
     "dargs": "~0.1.0",
     "async": "~0.2.8",
-    "inquirer": "~0.1.3"
+    "inquirer": "~0.2.0"
   },
   "devDependencies": {
     "mocha": "~1.11.0",


### PR DESCRIPTION
Hi there,

Inquirer 0.2 just been launched.

It adds a couple new features:
- New prompts: `expand`, `checkbox` and `password`
- Unicode char now used for Mac and Linux env
- `choices` array can now be a function to allow filtering available choices depending on previous answers
- Tests and internal refactoring for easier maintainability and a more robust support for differents OS

Also, as there's now a prompt type supporting the old conflicter interface, I updated the conflicter to use the new `expand` prompt.

![Expand prompt closed](https://dl.dropboxusercontent.com/u/59696254/inquirer/expand-prompt-1.png)
![Expand prompt expanded](https://dl.dropboxusercontent.com/u/59696254/inquirer/expand-prompt-2.png)
