### PR TITLE
(perf) speeding it up.

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -209,10 +209,23 @@ Environment.prototype.register = function register(name, namespace) {
     return this.error(new Error('You must provide a generator to register.'));
   }
 
-  var filepath = name;
+  var cachePath = _.isString(name);
+  var generator = cachePath ? function () {} : name;
 
-  var generator;
-  if (typeof name === 'string') {
+  var isRaw = function (generator) {
+    generator = Object.getPrototypeOf(generator.prototype);
+    var methods = ['option', 'argument', 'hookFor', 'run'];
+    return methods.filter(function (method) {
+      return !!generator[method];
+    }).length !== methods.length;
+  };
+
+  var filepath;
+  var ns;
+
+  if (cachePath) {
+    filepath = name;
+
     if (filepath.charAt(0) === '.') {
       filepath = path.resolve(filepath);
     }
@@ -221,19 +234,16 @@ Environment.prototype.register = function register(name, namespace) {
       filepath = process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME'] + filepath.slice(1);
     }
 
-    generator = require(filepath);
     generator.resolved = require.resolve(filepath);
     generator.namespace = this.namespace(generator.resolved);
-  } else {
-    generator = name;
+    generator.__register = function () {
+      var invokedGenerator = require(generator.resolved);
+      invokedGenerator.resolved = generator.resolved;
+      this.register(invokedGenerator, generator.namespace);
+    }.bind(this);
   }
 
-  if (typeof generator !== 'function') {
-    return this.error(new Error('Generators must be exposed as a function.'));
-  }
-
-  var parents = Object.getPrototypeOf(generator.prototype);
-  var ns = namespace || generator.namespace || this.namespace(name);
+  ns = namespace || generator.namespace || this.namespace(name);
 
   if (!ns) {
     return this.error(new Error('Unable to determine namespace.'));
@@ -246,19 +256,8 @@ Environment.prototype.register = function register(name, namespace) {
     ns = path.basename(path.dirname(ns));
   }
 
-  // we can't rely on instanceof, as our Base object is different than the one
-  // require()-d in the generator (unless it was npm linked)
-  //
-  // so, we detect if it looks like a Base generator.
-
-  var methods = ['option', 'argument', 'hookFor', 'run'];
-  var isBase = methods.filter(function (method) {
-    return !!parents[method];
-  }).length === methods.length;
-
-
   generator.namespace = ns;
-  generator.raw = !isBase;
+  generator.raw = isRaw(generator);
   generator.resolved = generator.resolved || ns;
   this.generators[ns] = generator;
 
@@ -285,18 +284,20 @@ Environment.prototype.get = function get(namespace) {
     return;
   }
 
-  var generator = this.generators[namespace];
-  if (generator) {
-    return generator;
-  }
+  var get = function (namespace) {
+    var generator = this.generators[namespace];
+    if (generator) {
+      if (generator.__register) {
+        generator.__register();
+        generator = get(namespace);
+      }
+      return generator;
+    }
+  }.bind(this);
 
-  var alias = this.alias(namespace);
-  generator = this.generators[alias];
-  if (generator) {
-    return generator;
-  }
-
-  return this.get(namespace.split(':').slice(0, -1).join(':'));
+  return get(namespace)
+    || get(this.alias(namespace))
+    || this.get(namespace.split(':').slice(0, -1).join(':'));
 };
 
 // Create is the Generator factory. It takes a namespace to lookup and optional


### PR DESCRIPTION
(#202)

Hmm, see what you think.

As discussed, require.resolve() is used to find the path of the module, but not load it until necessary.

I don't find the implementation all that pretty, so if you have any suggestions, please share!
