### PR TITLE
Add undefined check for expandFiles

### DIFF
--- a/lib/actions/file.js
+++ b/lib/actions/file.js
@@ -27,6 +27,7 @@ file.expand = function expand(pattern, options) {
 //
 // Returns an Array of filenames matching the pattern
 file.expandFiles = function expandFiles(pattern, options) {
+  options = options || {};
   var cwd = options.cwd || process.cwd();
   return this.expand(pattern, options).filter(function (filepath) {
     return fs.statSync(path.join(cwd, filepath)).isFile();

--- a/test/actions.js
+++ b/test/actions.js
@@ -345,4 +345,19 @@ describe('yeoman.generators.Base', function () {
       });
     });
   });
+
+  describe('generator.expandFiles', function () {
+    before(function (done) {
+      this.dummy.copy('foo.js', 'write/abc/abc.js');
+      this.dummy.conflicter.resolve(done);
+    });
+    it('should return expand files', function () {
+      var files = this.dummy.expandFiles('write/abc/**');
+      assert.deepEqual(files, ['write/abc/abc.js']);
+    });
+    it('should return expand files', function () {
+      var files = this.dummy.expandFiles('abc/**', {cwd: './write'});
+      assert.deepEqual(files, ['abc/abc.js']);
+    });
+  });
 });


### PR DESCRIPTION
if `options` is undefined in `expandFiles` function, this method throws exceptions like `Cannot read property 'cwd' of undefined`.
So I add a check options is `undefined` or not.

If you accept this fix, please merge.
