### PR TITLE
Update Inquirer for 0.3 release

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,6 +29,9 @@ var generators = module.exports = function createEnv(args, opts) {
   return new Environment(args, opts);
 };
 
+// Reference general dependencies on the top level object
+generators.inquirer = require('inquirer');
+
 // hoist up top level class the generator extend
 generators.Base = require('./lib/base');
 generators.NamedBase = require('./lib/named-base');

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "isbinaryfile": "~0.1.8",
     "dargs": "~0.1.0",
     "async": "~0.2.8",
-    "inquirer": "~0.2.0",
+    "inquirer": "~0.3.1",
     "iconv-lite": "~0.2.10",
     "shelljs": "~0.1.4",
     "findup-sync": "~0.1.2",


### PR DESCRIPTION
A new Inquirer minor release is out adding list pagination (for more than 10 items), choices separators (basically unselectable free-edit lines) and 1-9 shortcut keys.
