### PR TITLE
Refactor env.register logic (Fix #353)

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -525,7 +525,7 @@ Base.prototype.optionsHelp = function optionsHelp() {
 
 Base.prototype.rootGeneratorName = function () {
   var path = findup('package.json', { cwd: this.resolved });
-  return JSON.parse(fs.readFileSync(path, 'utf8')).name;
+  return path ? JSON.parse(fs.readFileSync(path, 'utf8')).name : '*';
 };
 
 /**

--- a/lib/env.js
+++ b/lib/env.js
@@ -176,7 +176,7 @@ Environment.prototype.help = function help(name) {
     groups[base] = groups[base].concat(namespace);
   });
 
-  Object.keys(groups).forEach(function (key) {
+  Object.keys(groups).sort().forEach(function (key) {
     var group = groups[key];
 
     if (group.length >= 1) {
@@ -213,45 +213,27 @@ Environment.prototype.help = function help(name) {
  */
 
 Environment.prototype.register = function register(name, namespace) {
-  if (!name) {
-    return this.error(new Error('You must provide a generator to register.'));
+  if (!_.isString(name)) {
+    return this.error(new Error('You must provide a generator name to register.'));
   }
 
-  var cachePath = _.isString(name);
-  var generator = cachePath ? function () {} : name;
-
-  var isRaw = function (generator) {
-    generator = Object.getPrototypeOf(generator.prototype);
-    var methods = ['option', 'argument', 'hookFor', 'run'];
-    return methods.filter(function (method) {
-      return !!generator[method];
-    }).length !== methods.length;
-  };
-
-  var filepath;
+  var self = this;
+  var filepath = name;
   var ns;
 
-  if (cachePath) {
-    filepath = name;
-
-    if (filepath.charAt(0) === '.') {
-      filepath = path.resolve(filepath);
-    }
-
-    if (filepath.charAt(0) === '~') {
-      filepath = process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME'] + filepath.slice(1);
-    }
-
-    generator.resolved = require.resolve(filepath);
-    generator.namespace = this.namespace(generator.resolved);
-    generator.__register = function () {
-      var invokedGenerator = require(generator.resolved);
-      invokedGenerator.resolved = generator.resolved;
-      this.register(invokedGenerator, generator.namespace);
-    }.bind(this);
+  if (filepath[0] === '.') {
+    filepath = path.resolve(filepath);
   }
 
-  ns = namespace || generator.namespace || this.namespace(name);
+  if (filepath[0] === '~') {
+    filepath = process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME'] + filepath.slice(1);
+  }
+
+  var generatorProps = {};
+  generatorProps.resolved = require.resolve(filepath);
+  generatorProps.namespace = this.namespace(generatorProps.resolved);
+
+  ns = namespace || generatorProps.namespace || this.namespace(name);
 
   if (!ns) {
     return this.error(new Error('Unable to determine namespace.'));
@@ -264,12 +246,54 @@ Environment.prototype.register = function register(name, namespace) {
     ns = path.basename(path.dirname(ns));
   }
 
-  generator.namespace = ns;
-  generator.raw = isRaw(generator);
-  generator.resolved = generator.resolved || ns;
-  this.generators[ns] = generator;
+  Object.defineProperty(this.generators, ns, {
+    get: function () {
+      var Generator = require(generatorProps.resolved);
+      Generator.resolved = generatorProps.resolved;
+      Generator.namespace = generatorProps.namespace;
+      return Generator;
+    },
+    set: function (val) {
+      Object.defineProperty(self.generators, ns, {
+        value: val,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
+    },
+    enumerable: true,
+    configurable: true
+  });
 
-  debug('Registered %s (%s)', generator.namespace, generator.resolved);
+  debug('Registered %s (%s)', generatorProps.namespace, generatorProps.resolved);
+  return this;
+};
+
+Environment.prototype.registerStub = function registerStub(Generator, namespace) {
+  if (!_.isFunction(Generator)) {
+    return this.error(new Error('You must provide a stub function to register.'));
+  }
+
+  var isRaw = function (generator) {
+    generator = Object.getPrototypeOf(generator.prototype);
+    var methods = ['option', 'argument', 'hookFor', 'run'];
+    return methods.filter(function (method) {
+      return !!generator[method];
+    }).length !== methods.length;
+  };
+
+  if (isRaw(Generator)) {
+    var newGenerator = function () {
+      Base.apply(this, arguments);
+    };
+    util.inherits(newGenerator, Base);
+    newGenerator.prototype.exec = Generator;
+    Generator = newGenerator;
+  }
+
+  Generator.resolved = 'lorem';
+
+  this.generators[namespace] = Generator;
   return this;
 };
 
@@ -297,14 +321,7 @@ Environment.prototype.get = function get(namespace) {
   }
 
   var get = function (namespace) {
-    var generator = this.generators[namespace];
-    if (generator) {
-      if (generator.__register) {
-        generator.__register();
-        generator = get(namespace);
-      }
-      return generator;
-    }
+    return this.generators[namespace];
   }.bind(this);
 
   return get(namespace)
@@ -329,14 +346,14 @@ Environment.prototype.create = function create(namespace, options) {
   var names = namespace.split(':');
   var name = names.slice(-1)[0];
 
-  var generator = this.get(namespace);
+  var Generator = this.get(namespace);
 
   var args = options.arguments || options.args || this.arguments;
   args = Array.isArray(args) ? args : args.split(' ');
 
   var opts = options.options || _.clone(this.options);
 
-  if (!generator) {
+  if (!Generator) {
     return this.error(
       new Error(
         'You don\'t seem to have a generator with the name ' + namespace + ' installed.\n' +
@@ -347,22 +364,9 @@ Environment.prototype.create = function create(namespace, options) {
     );
   }
 
-  // case of raw functions, we create a brand new `Base` object and attach this
-  // raw function as one of the prototype method. this effectively standardize
-  // the interface for running generators, while allowing less boilerplate for
-  // generators authors.
-  var Generator = generator;
-  if (generator.raw) {
-    Generator = function () {
-      Base.apply(this, arguments);
-    };
-    util.inherits(Generator, Base);
-    Generator.prototype.exec = generator;
-  }
-
   opts.env = this;
   opts.name = name;
-  opts.resolved = generator.resolved;
+  opts.resolved = Generator.resolved;
   return new Generator(args, opts);
 };
 

--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -213,9 +213,9 @@ helpers.createGenerator = function (name, dependencies, args, options) {
   var env = generators();
   dependencies.forEach(function (d) {
     if (d instanceof Array) {
-      env.register(d[0], d[1]);
+      env.registerStub(d[0], d[1]);
     } else {
-      env.register(d);
+      env.registerStub(d);
     }
   });
 

--- a/test/actions.js
+++ b/test/actions.js
@@ -15,18 +15,8 @@ describe('yeoman.generators.Base', function () {
   before(generators.test.before(path.join(__dirname, 'temp')));
 
   before(function () {
-    function Dummy() {
-      generators.Base.apply(this, arguments);
-    }
-
-    util.inherits(Dummy, generators.Base);
-
-    Dummy.prototype.test = function () {
-      this.shouldRun = true;
-    };
-
     var env = this.env = generators();
-    env.register(Dummy, 'dummy');
+    env.registerStub(generators.test.createDummyGenerator(), 'dummy');
     this.dummy = env.create('dummy');
 
     this.fixtures = path.join(__dirname, 'fixtures');

--- a/test/base.js
+++ b/test/base.js
@@ -18,21 +18,13 @@ describe('yeoman.generators.Base', function () {
   before(function () {
     var env = this.env = generators();
 
-    function Dummy() {
-      generators.Base.apply(this, arguments);
-    }
+    var Dummy = generators.test.createDummyGenerator();
 
-    util.inherits(Dummy, generators.Base);
-
-    Dummy.prototype.test = function () {
-      this.shouldRun = true;
-    };
-
-    env.register(Dummy, 'ember:all');
-    env.register(Dummy, 'hook1:ember');
-    env.register(Dummy, 'hook2:ember:all');
-    env.register(Dummy, 'hook3');
-    env.register(function () {
+    env.registerStub(Dummy, 'ember:all');
+    env.registerStub(Dummy, 'hook1:ember');
+    env.registerStub(Dummy, 'hook2:ember:all');
+    env.registerStub(Dummy, 'hook3');
+    env.registerStub(function () {
       this.write('app/scripts/models/application-model.js', '// ...');
     }, 'hook4');
 

--- a/test/env.js
+++ b/test/env.js
@@ -77,6 +77,21 @@ describe('Environment', function () {
       assert.ok(extend);
       assert.ok(typeof extend === 'function');
       assert.ok(extend.namespace, 'scaffold');
+
+      // should only accept String as first parameter
+      assert.throws(function () { env.register(function () {}, 'blop'); });
+      assert.throws(function () { env.register([], 'blop'); });
+      assert.throws(function () { env.register(false, 'blop'); });
+    });
+
+    // Make sure we don't break the generators hash using `Object.defineProperty`
+    it('should keep internal generators object writable', function () {
+      var env = generators();
+      env.register('../fixtures/custom-generator-simple', 'foo');
+      env.generators.foo = 'bar';
+      assert.equal(env.generators.foo, 'bar');
+      env.generators.foo = 'yo';
+      assert.equal(env.generators.foo, 'yo');
     });
 
     it('get the list of namespaces', function () {
@@ -263,7 +278,7 @@ describe('Environment', function () {
       }
 
       generators()
-        .register(this.Generator)
+        .registerStub(this.Generator, 'angular:all')
         // Series of events proxied from the resolved generator
         .on('generators:start', assertEvent('generators:start'))
         .on('generators:end', assertEvent('generators:end'))

--- a/test/fallbacks.js
+++ b/test/fallbacks.js
@@ -8,7 +8,7 @@ var helpers = generators.test;
 describe('generators config', function () {
   describe('when config("generators.test-framework") is set', function () {
     before(function () {
-      this.env = generators().register(function () {}, 'ember:model');
+      this.env = generators().registerStub(function () {}, 'ember:model');
     });
 
     it('I get the appropriate generator.options', function () {

--- a/test/fixtures/mocha-generator/main.js
+++ b/test/fixtures/mocha-generator/main.js
@@ -12,10 +12,14 @@
 // It works with simple generator, if you need to do a bit more complex
 // stuff, extends from Generator.Base and defines your generator steps
 // in several methods.
+var util = require('util');
+var generators = require('../../../main');
 
 module.exports = function(args, options) {
+  generators.Base.apply(this, arguments);
   console.log('Executing generator with', args, options);
 };
+util.inherits(module.exports, generators.Base);
 
 module.exports.name = 'You can name your generator';
 module.exports.description = 'Ana add a custom description by adding a `description` property to your function.';


### PR DESCRIPTION
`env.register` now only accept the generator path as a String. This force
the `generator.resolved` behaviour to be consistent. At the same time,
removed any check for `generator.raw`; this is an unexpected side effect
and obfuscate the code for very little gain.

Added `env.registerStub` method to allow adding stub generators as
function to the environment. A check is made on the function passed
to force stubbed generators to extend Base (this is done automatically).

Some test mechanics needed to be fixed in order to pass. This shouldn't
have changed the tests logic.

---

The motivation behind this change is explained in #353. Basically it's a follow up after the 1.0 release bug to update what felt to me like an error prone logic and to make sure `generator.resolved` value was consistent no matter what.
