### PR TITLE
Change message displayed to user during install

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -110,7 +110,7 @@ install.installDependencies = function (options) {
   }
 
   if (!options.skipMessage) {
-    console.log(msg.template(_.extend(options, { commands: chalk.yellow.bold(msg.commands.join(' & ')) })));
+    console.log(msg.template(_.extend(options, { commands: chalk.yellow.bold(msg.commands.join(' && ')) })));
   }
 
   if (!options.skipInstall) {


### PR DESCRIPTION
This makes the display message 
`I'm all done. Running bower install && npm install for you to install the required dependencies.`

Instead of 

`I'm all done. Running bower install & npm install for you to install the required dependencies.`

Which allows you to copy and paste into a terminal and run them manually.
