### PR TITLE
#350 Reverted conflicter back to old style series function to prevent maximum call stack error

### DIFF
--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -48,30 +48,22 @@ conflicter.shift = function shift() {
 };
 
 conflicter.resolve = function resolve(cb) {
-  var resolveConflicts = function (conflict) {
-    return function (next) {
-      if (!conflict) {
-        return next();
-      }
-
-      conflicter.collision(conflict.file, conflict.content, function (status) {
-        conflicter.emit('resolved:' + conflict.file, {
-          status: status,
-          callback: next
-        });
-      });
-    };
-  };
-
-  async.series(this.conflicts.map(resolveConflicts), function (err) {
-    if (err) {
-      cb();
-      return self.emit('error', err);
+  var conflicts = this.conflicts;
+  (function next(conflict) {
+    if (!conflict) {
+      conflicter.reset();
+      return cb();
     }
 
-    conflicter.reset();
-    cb();
-  }.bind(this));
+    conflicter.collision(conflict.file, conflict.content, function (status) {
+      conflicter.emit('resolved:' + conflict.file, {
+        status: status,
+        callback: next
+      });
+      next(conflicts.shift());
+    });
+
+  })(conflicts.shift());
 };
 
 conflicter._ask = function (filepath, content, cb) {


### PR DESCRIPTION
This is basically reverting back to what it was before.  I just added back in the new status and the call to `conflicter.reset()`.
