### PR TITLE
Bulk copy feature #350

### DIFF
--- a/lib/actions/actions.js
+++ b/lib/actions/actions.js
@@ -72,17 +72,8 @@ actions.cacheRoot = function cacheRoot() {
   return path.join(home, '.cache/yeoman');
 };
 
-/**
- * Make some of the file API aware of our source/destination root paths.
- * `copy`, `template` (only when could be applied/required by legacy code),
- * `write` and alike consider.
- *
- * @param {String} source
- * @param {String} destination
- * @param {Function} process
- */
-
-actions.copy = function copy(source, destination, process) {
+// Copy helper for two versions of copy action
+function prepCopy(source, destination, process) {
   var body;
   destination = destination || source;
 
@@ -107,14 +98,36 @@ actions.copy = function copy(source, destination, process) {
     });
   }
 
+  return {
+    body: body,
+    encoding: encoding,
+    destination: destination,
+    source: source
+  };
+};
+
+/**
+ * Make some of the file API aware of our source/destination root paths.
+ * `copy`, `template` (only when could be applied/required by legacy code),
+ * `write` and alike consider.
+ *
+ * @param {String} source
+ * @param {String} destination
+ * @param {Function} process
+ */
+
+actions.copy = function copy(source, destination, process) {
+
+  var file = prepCopy.call(this, source, destination, process);
+ 
   try {
-    body = this.engine(body, this);
+    file.body = this.engine(file.body, this);
   } catch (err) {
     // this happens in some cases when trying to copy a JS file like lodash/underscore
     // (conflicting the templating engine)
   }
 
-  this.checkForCollision(destination, body, function (err, config) {
+  this.checkForCollision(file.destination, file.body, function (err, config) {
     var stats;
 
     if (err) {
@@ -128,21 +141,54 @@ actions.copy = function copy(source, destination, process) {
       return config.callback();
     }
 
-    mkdirp.sync(path.dirname(destination));
-    fs.writeFileSync(destination, body);
+    mkdirp.sync(path.dirname(file.destination));
+    fs.writeFileSync(file.destination, file.body);
 
     // synchronize stats and modification times from the original file.
-    stats = fs.statSync(source);
+    stats = fs.statSync(file.source);
     try {
-      fs.chmodSync(destination, stats.mode);
-      fs.utimesSync(destination, stats.atime, stats.mtime);
+      fs.chmodSync(file.destination, stats.mode);
+      fs.utimesSync(file.destination, stats.atime, stats.mtime);
     } catch (err) {
-      this.log.error('Error setting permissions of "' + chalk.bold(destination) + '" file: ' + err);
+      this.log.error('Error setting permissions of "' + chalk.bold(file.destination) + '" file: ' + err);
     }
 
     config.callback();
   }.bind(this));
 
+  return this;
+};
+
+/**
+ * Bulk copy
+ * https://github.com/yeoman/generator/pull/359
+ * https://github.com/yeoman/generator/issues/350
+ *
+ * An optimized copy method for larger file trees.  Does not do
+ * full conflicter checks, only check ir root directory is not empty.
+ *
+ * @param {String} source
+ * @param {String} destination
+ * @param {Function} process
+ */
+
+actions.bulkCopy = function bulkCopy(source, destination, process) {
+
+  var file = prepCopy.call(this, source, destination, process);
+
+  mkdirp.sync(path.dirname(file.destination));
+  fs.writeFileSync(file.destination, file.body);
+
+  // synchronize stats and modification times from the original file.
+  stats = fs.statSync(file.source);
+  try {
+    fs.chmodSync(file.destination, stats.mode);
+    fs.utimesSync(file.destination, stats.atime, stats.mtime);
+  } catch (err) {
+    this.log.error('Error setting permissions of "' + chalk.bold(file.destination) + '" file: ' + err);
+  }
+
+  log.create(file.destination);
   return this;
 };
 
@@ -292,6 +338,32 @@ actions.engine = function engine(body, data) {
     body;
 };
 
+// Shared directory method
+function _directory(source, destination, process, bulk) {
+  var root = path.join(this.sourceRoot(), source);
+  var files = this.expandFiles('**', { dot: true, cwd: root });
+
+  destination = destination || source;
+
+  if (typeof destination === 'function') {
+    process = destination;
+    destination = source;
+  }
+
+  var cp = this.copy;
+  if (bulk) {
+    cp = this.bulkCopy;
+  }
+
+  // get the path relative to the template root, and copy to the relative destination
+  for (var i in files) {
+    var dest = path.join(destination, files[i]);
+    cp.call(this, path.join(root, files[i]), dest, process);
+  }
+
+  return this;
+};
+
 /**
  * Copies recursively the files from source directory to root directory.
  *
@@ -301,34 +373,29 @@ actions.engine = function engine(body, data) {
  */
 
 actions.directory = function directory(source, destination, process) {
-  var root = path.join(this.sourceRoot(), source);
-  var files = this.expandFiles('**', { dot: true, cwd: root });
+  return _directory.call(this, source, destination, process);
+};
+
+/**
+ * Copies recursively the files from source directory to root directory.
+ *
+ * @param {String} source
+ * @param {String} destination
+ * @param {Function} process
+ */
+
+actions.bulkDirectory = function directory(source, destination, process) {
   var self = this;
+  this.checkForCollision(destination, null, function (err, config) {
+    // create or force means file write, identical or skip prevent the
+    // actual write.
+    if (!(/force|create/.test(config.status))) {
+      return config.callback();
+    }
 
-  destination = destination || source;
-
-  if (typeof destination === 'function') {
-    process = destination;
-    destination = source;
-  }
-
-  // get the path relative to the template root, and copy to the relative destination
-  var resolveFiles = function (filepath) {
-    return function (next) {
-      if (!filepath) {
-        self.emit('directory:end');
-        return next();
-      }
-
-      var dest = path.join(destination, filepath);
-      self.copy(path.join(root, filepath), dest, process);
-
-      return next();
-    };
-  };
-
-  async.parallel(files.map(resolveFiles));
-
+    _directory.call(this, source, destination, process, true);
+    config.callback();
+  });
   return this;
 };
 

--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -143,22 +143,24 @@ conflicter.collision = function collision(filepath, content, cb) {
     return cb('create');
   }
 
-  var encoding = null;
-  if (!isBinaryFile(path.resolve(filepath))) {
-    encoding = 'utf8';
-  }
+  if (!fs.statSync(path.resolve(filepath)).isDirectory()) {
+    var encoding = null;
+    if (!isBinaryFile(path.resolve(filepath))) {
+      encoding = 'utf8';
+    }
 
-  var actual = fs.readFileSync(path.resolve(filepath), encoding);
+    var actual = fs.readFileSync(path.resolve(filepath), encoding);
 
-  // In case of binary content, `actual` and `content` are `Buffer` objects,
-  // we just can't compare those 2 objects with standard `===`,
-  // so we convert each binary content to an hexadecimal string first, and then compare them with standard `===`
-  //
-  // For not binary content, we can directly compare the 2 strings this way
-  if ((!encoding && (actual.toString('hex') === content.toString('hex'))) ||
-      (actual === content)) {
-    log.identical(filepath);
-    return cb('identical');
+    // In case of binary content, `actual` and `content` are `Buffer` objects,
+    // we just can't compare those 2 objects with standard `===`,
+    // so we convert each binary content to an hexadecimal string first, and then compare them with standard `===`
+    //
+    // For not binary content, we can directly compare the 2 strings this way
+    if ((!encoding && (actual.toString('hex') === content.toString('hex'))) ||
+    (actual === content)) {
+      log.identical(filepath);
+      return cb('identical');
+    }
   }
 
   if (self.force) {


### PR DESCRIPTION
Added ability to skip processing on large directory copies.  This implementation uses a fourth parameter to both `directory` and `copy` which allows for files to not be checked in the conflicter or run through the template engine.
