### PR TITLE
generator.remote();  added --force flag to tell npm to fetch upstream even when cache hit

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -723,7 +723,7 @@ Environment.prototype.plugins = function plugins(filename, basedir) {
 Environment.prototype.remote = function remote(name, done) {
   var self = this;
   log.write().info('Installing remote package %s', name).write();
-  var npm = spawn('npm', ['install', name, '--save-dev']);
+  var npm = spawn('npm', ['install', name, '--save-dev', '--force']);
   npm.stdout.pipe(process.stdout);
   npm.stderr.pipe(process.stderr);
   done = done || function () {};


### PR DESCRIPTION
I have a simple generator that is just pulling a pre-set boilerplate with yo.  The problem is that when the boilerplate repo is updated, yo.remote() does not perform a git fetch.

Here is the remote call:
https://github.com/mixdown/generator-mixdown/blob/master/app/index.js#L25

To resolve, I have to tell users to do the following:

```
rm -rf  /Users/your-user-name/.cache/yeoman/mixdown
```

_From npm docs_
The --force argument will force npm to fetch remote resources even if a local copy exists on disk.
