### PR TITLE
Add test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ node_js:
   - '0.10'
   - '0.8'
 before_script:
-  npm install -g bower
+  npm install -g bower mocha istanbul
 env:
   - DEBUG="generators:*"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git://github.com/yeoman/generator.git"
   },
   "scripts": {
-    "test": "mocha test/*.js --reporter list --timeout 100000",
+    "test": "istanbul cover _mocha --report lcovonly -- test/*.js --reporter list --timeout 100000 && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "legacy": "mocha test/legacy.js --reporter dot --timeout 100000",
     "test-generator": "mocha test/generators/*.js --reporter spec --timeout 100000"
   },
@@ -49,6 +49,9 @@
     "mocha": "~1.12.0",
     "proxyquire": "~0.4.0",
     "sinon": "~1.7.3",
-    "markdox": "~0.1.2"
+    "markdox": "~0.1.2",
+    "coveralls": "~2.3.0",
+    "mocha-lcov-reporter": "0.0.1",
+    "istanbul": "~0.1.44"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Generator [![Build Status](https://secure.travis-ci.org/yeoman/generator.png?branch=master)](http://travis-ci.org/yeoman/generator)
+# Generator [![Build Status](https://secure.travis-ci.org/yeoman/generator.png?branch=master)](http://travis-ci.org/yeoman/generator) [![Coverage Status](https://coveralls.io/repos/yeoman/generator/badge.png)](https://coveralls.io/r/yeoman/generator)
 
 A Rails-inspired generator system that provides scaffolding for your apps.
 


### PR DESCRIPTION
Istanbul test coverage and coveralls integration.

Test is failing because Coveralls is not activated on Yeoman. You can see though the coverage report at the end of the build.

Now that I'm a Yeoman team member, can I get access to the organization and write-access? I could setup coveralls reports and make this PR pass.
