### PR TITLE
Add scoped helpers environments from file-utils

### DIFF
--- a/lib/actions/actions.js
+++ b/lib/actions/actions.js
@@ -119,7 +119,7 @@ function prepCopy(source, destination, process) {
 actions.copy = function copy(source, destination, process) {
 
   var file = prepCopy.call(this, source, destination, process);
- 
+
   try {
     file.body = this.engine(file.body, this);
   } catch (err) {

--- a/lib/base.js
+++ b/lib/base.js
@@ -6,11 +6,15 @@ var _ = require('lodash');
 var async = require('async');
 var findup = require('findup-sync');
 var chalk = require('chalk');
+var file = require('file-utils');
 
 var engines = require('./util/engines');
 var conflicter = require('./util/conflicter');
 var Storage = require('./util/storage');
 var actions = require('./actions/actions');
+
+var noop = function () {};
+var fileLogger = { write: noop, warn: noop };
 
 // TOOD(mklabs): flesh out api, remove config (merge with options, or just remove the
 // grunt config handling)
@@ -26,6 +30,7 @@ var actions = require('./actions/actions');
  */
 
 var Base = module.exports = function Base(args, options) {
+  var self = this;
   events.EventEmitter.call(this);
 
   if (!Array.isArray(args)) {
@@ -88,6 +93,22 @@ var Base = module.exports = function Base(args, options) {
     alias: 'h',
     desc: 'Print generator\'s options and usage'
   });
+
+  // Set the file-utils environments
+  // Set logger as a noop as logging is handled by the yeoman conflicter
+  this.src = file.createEnv({
+    base: this.sourceRoot(),
+    dest: this.destinationRoot(),
+    logger: fileLogger
+  });
+  this.dest = file.createEnv({
+    base: this.destinationRoot(),
+    dest: this.sourceRoot(),
+    logger: fileLogger
+  });
+
+  this.dest.registerValidationFilter('collision', this.getCollisionFilter());
+  this.src.registerValidationFilter('collision', this.getCollisionFilter());
 
   // ensure source/destination path, can be configured from subclasses
   this.sourceRoot(path.join(path.dirname(this.resolved), 'templates'));
@@ -538,16 +559,72 @@ Base.prototype._setStorage = function () {
 };
 
 /**
- * Façace `actions.destinationRoot` on Base generator so it update the storage
- * path when the path change.
- *
- * @param {String} rootPath
+ * Change the generator destination root directory.
+ * This method façade the lib/actions/actions.js method so it can update the storage and
+ * the file-utils environments.
+ * @param  {String} rootPath new destination root path
+ * @return {String}          destination root path
  */
 
 Base.prototype.destinationRoot = function (rootPath) {
   var root = actions.destinationRoot.call(this, rootPath);
-  if (rootPath) {
+
+  if (_.isString(rootPath)) {
     this._setStorage();
+
+    // Update file helpers path bases
+    this.dest.setBase(root);
+    this.src.setDestBase(root);
   }
+
   return root;
 };
+
+/**
+ * Change the generator source root directory.
+ * This method façade the lib/actions/actions.js method so it can update the
+ * file-utils environments.
+ * @param  {String} rootPath new source root path
+ * @return {String}          source root path
+ */
+
+Base.prototype.sourceRoot = function (rootPath) {
+  var root = actions.sourceRoot.call(this, rootPath);
+
+  if (_.isString(rootPath)) {
+    // Update file helpers path bases
+    this.src.setBase(root);
+    this.dest.setDestBase(root);
+  }
+
+  return root;
+};
+
+
+/**
+ * Return a file Env validation filter checking for collision
+ */
+
+Base.prototype.getCollisionFilter = function () {
+  var self = this;
+  return function checkForCollisionFilter(output) {
+    var done = this.async();
+
+    self.checkForCollision(output.path, output.contents, function (err, config) {
+      if (err) {
+        done(false);
+        config.callback(err);
+        return this.emit('error', err);
+      }
+
+      if (!(/force|create/.test(config.status))) {
+        done('Skip modifications to ' + output.path);
+      }
+
+      done(true);
+      return config.callback();
+    });
+  }
+
+};
+

--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -4,8 +4,8 @@ var rimraf = require('rimraf');
 var mkdirp = require('mkdirp');
 var util = require('util');
 var assert = require('assert');
+var _ = require('lodash');
 var generators = require('../..');
-
 
 // Mocha helpers
 var helpers = module.exports;
@@ -145,6 +145,22 @@ helpers.assertTextEqual = function (value, expected) {
   }
 
   assert.equal(eol(value), eol(expected));
+};
+
+/**
+ * Assert an Object implement and interface
+ * @param  {Object} obj       subject implementing the façade
+ * @param  {Object|Array} interface a façace, hash or array of keys to be implemented
+ */
+
+helpers.assertImplement = function(obj, interface) {
+  var methods = _.isArray(interface) ? interface : Object.keys(interface);
+  var pass = methods.reduce(function(rest, method) {
+    if (obj[method] != null) return true;
+    return rest;
+  }, false);
+
+  assert.ok(pass);
 };
 
 // Clean-up the test directory and ce into it.

--- a/main.js
+++ b/main.js
@@ -32,6 +32,9 @@ var generators = module.exports = function createEnv(args, opts) {
 // Reference general dependencies on the top level object
 generators.inquirer = require('inquirer');
 
+// Set global file utility
+generators.file = require('file-utils');
+
 // hoist up top level class the generator extend
 generators.Base = require('./lib/base');
 generators.NamedBase = require('./lib/named-base');

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "chalk": "~0.2.0",
     "text-table": "~0.2.0",
     "download": "~0.1.6",
-    "request": "~2.27.0"
+    "request": "~2.27.0",
+    "file-utils": "~0.1.1"
   },
   "devDependencies": {
     "mocha": "~1.13.0",

--- a/test/fixtures/file-conflict.txt
+++ b/test/fixtures/file-conflict.txt
@@ -1,0 +1,1 @@
+initial content


### PR DESCRIPTION
Base generator now expose `.src` and `.dest` who're file-utils
environment scope as the sourceRoot and destinationRoot. This will allow
access to more file helpers method, and also more transparent process
for filtering, transpiling and validation (conflicter).

This is a follow up commit after #313 discussion. As Grunt team ain't yet moving on exporting Grunt.file into a standalone module, it felt important to me we moved on this one as it felt a major piece for future generator user customization (style guide, JS || coffeescript, etc).

The standalone module is here: https://github.com/SBoudrias/file-utils  
And I implemented a simple demo on Generator-bbb: https://github.com/backbone-boilerplate/generator-bbb/compare/remove-grunt (Generator-bbb was using grunt.file so the file methods stay the same and ain't shown clearly in the diff, but the filters are used extensively to write file in the correct style guide).
