### PR TITLE
Update Base.tarball test so it don't rely on network

### DIFF
--- a/lib/actions/fetch.js
+++ b/lib/actions/fetch.js
@@ -32,7 +32,7 @@ fetch.fetch = function _fetch(url, destination, cb) {
 };
 
 /**
- * Fetch a string or an array of archives and extract it/them to a given 
+ * Fetch a string or an array of archives and extract it/them to a given
  * destination.
  *
  * @param {String|Array} archive


### PR DESCRIPTION
The `.tarball` test constantly fails on TravisCI and is overall pretty long to run locally.

I mocked the `download` NPM module that it façade to test it without sending request through the networks. This way, it'll stop failing Travis due to connections timeouts.

If we trust `download` module, I don't think it is necessary to test it on the network on our side.
