### PR TITLE
Abstract Base.prototype.prompt to support non-cli env.

### DIFF
--- a/lib/actions/actions.js
+++ b/lib/actions/actions.js
@@ -1,6 +1,3 @@
-var logger = process.logging || require('../util/log');
-var log = logger('generators:action');
-
 var fs = require('fs');
 var path = require('path');
 var events = require('events');
@@ -13,7 +10,7 @@ var chalk = require('chalk');
 
 var actions = module.exports;
 
-actions.log = log;
+
 
 /**
  * Stores and return the cache root for this class. The cache root is used to
@@ -149,7 +146,7 @@ actions.bulkCopy = function bulkCopy(source, destination, process) {
     this.log.error('Error setting permissions of "' + chalk.bold(file.destination) + '" file: ' + err);
   }
 
-  log.create(file.destination);
+  this.log.create(file.destination);
   return this;
 };
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -9,7 +9,7 @@ var chalk = require('chalk');
 var file = require('file-utils');
 
 var engines = require('./util/engines');
-var conflicter = require('./util/conflicter');
+var Conflicter = require('./util/conflicter');
 var Storage = require('./util/storage');
 
 var noop = function () {};
@@ -71,7 +71,7 @@ var Base = module.exports = function Base(args, options) {
     delete this.options.engine;
   }
 
-  this.conflicter = conflicter;
+  this.conflicter = new Conflicter(this.env.adapter);
   this.conflicter.force = this.options.force;
 
   // determine the app root
@@ -125,7 +125,24 @@ _.extend(Base.prototype, require('./actions/wiring'));
 _.extend(Base.prototype, require('./util/common'));
 Base.prototype.user = require('./actions/user');
 Base.prototype.shell = require('shelljs');
-Base.prototype.prompt = require('./actions/prompt');
+
+Base.prototype.prompt = function (questions, callback) {
+  this.env.adapter.prompt(questions, callback);
+  return this;
+};
+
+//Since log is both a function and an object we need to use Object.defineProperty
+//instead of this.env.adapter.log.apply o similar approaches
+Object.defineProperty(Base.prototype, 'log', {
+  configurable: true,
+  enumerable: true,
+  get: function () {
+    return this.env.adapter.log;
+  }
+});
+
+
+
 Base.prototype.invoke = require('./actions/invoke');
 Base.prototype.spawnCommand = require('./actions/spawn_command');
 
@@ -588,7 +605,7 @@ Base.prototype.optionsHelp = function optionsHelp() {
       '--' + o.name,
       o.desc ? '# ' + o.desc : '',
       o.defaults == null ? '' : 'Default: ' + o.defaults
-    ];
+      ];
   });
 
   return this.log.table({

--- a/lib/env/adapter.js
+++ b/lib/env/adapter.js
@@ -1,0 +1,73 @@
+'use strict';
+
+var inquirer = require('inquirer');
+var diff = require('diff');
+var chalk = require('chalk');
+var logger = require('../util/log');
+
+
+/**
+ * `TerminalAdapter` is the default implementation of `Adapter`, an abstraction
+ * layer that defines the I/O interactions.
+ *
+ * It provides a CLI interaction
+ */
+var TerminalAdapter = module.exports = function TerminalAdapter() {};
+
+
+TerminalAdapter.prototype._colorDiffAdded = chalk.black.bgGreen;
+TerminalAdapter.prototype._colorDiffRemoved = chalk.bgRed;
+TerminalAdapter.prototype._colorLines = function colorLines(name, str) {
+  return str.split('\n').map(function (str) {
+    return this['_colorDiff' + name](str);
+  }, this).join('\n');
+};
+
+/**
+ * Prompt a user for one or more questions and pass
+ * the answer(s) to the provided callback.
+ *
+ * It shares its interface with `Base.prompt`
+ *
+ * @param {Array} questions
+ * @param {Function} callback
+ */
+TerminalAdapter.prototype.prompt = function _prompt() {
+  inquirer.prompt.apply(inquirer, arguments);
+};
+
+/**
+ * Shows a color-based diff of two strings
+ *
+ * @param {string} actual
+ * @param {string} expected
+ */
+TerminalAdapter.prototype.diff = function _diff(actual, expected) {
+  var msg = diff.diffLines(actual, expected).map(function (str) {
+    if (str.added) {
+      return this._colorLines('Added', str.value);
+    }
+
+    if (str.removed) {
+      return this._colorLines('Removed', str.value);
+    }
+
+    return str.value;
+  }, this).join('');
+
+  // legend
+  msg = '\n' +
+    this._colorDiffRemoved('removed') +
+    ' ' +
+    this._colorDiffAdded('added') +
+    '\n\n' +
+    msg +
+    '\n';
+
+  console.log(msg);
+  return msg;
+};
+
+TerminalAdapter.prototype.log = logger();
+
+

--- a/lib/env/index.js
+++ b/lib/env/index.js
@@ -5,13 +5,13 @@ var events = require('events');
 var spawn = require('child_process').spawn;
 var chalk = require('chalk');
 var _ = require('lodash');
-var log = process.logging('generators');
 
 var debug = require('debug')('generators:environment');
 
 var Base = require('../base');
 var Store = require('./store');
 var resolver = require('./resolver');
+var TerminalAdapter = require('./adapter');
 
 // TODO(mklabs):
 //
@@ -32,17 +32,22 @@ var resolver = require('./resolver');
  * `options`. Usually, this is the list of arguments you get back from your CLI
  * options parser.
  *
+ * An optional adapter can be passed to provide interaction in non-CLI environment
+ * (e.g. IDE plugins), otherwise a `TerminalAdapter` is instantiated by default
+ *
+ *
  * @param {String|Array} args
  * @param {Object} opts
+ * @param {Adapter} adaper
  */
 
-var Environment = module.exports = function Environment(args, opts) {
+var Environment = module.exports = function Environment(args, opts, adapter) {
   events.EventEmitter.call(this);
 
   args = args || [];
   this.arguments = Array.isArray(args) ? args : args.split(' ');
   this.options = opts || {};
-
+  this.adapter = adapter || new TerminalAdapter();
   this.cwd = this.options.cwd || process.cwd();
   this.store = new Store();
   this.aliases = [];

--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -1,20 +1,22 @@
-var logger = process.logging || require('./log');
+'use strict';
 
 var fs = require('fs');
 var path = require('path');
 var events = require('events');
-var diff = require('diff');
-var prompt = require('../actions/prompt');
-var log = logger('conflicter');
 var async = require('async');
 var isBinaryFile = require('isbinaryfile');
-var chalk = require('chalk');
+var util = require('util');
 
-var conflicter = module.exports = Object.create(events.EventEmitter.prototype);
+var Conflicter = module.exports = function Conflicter(adapter) {
+  events.EventEmitter.call(this);
+  this.adapter = adapter;
+  this.conflicts = [];
+};
 
-conflicter.conflicts = [];
+util.inherits(Conflicter, events.EventEmitter);
 
-conflicter.add = function add(conflict) {
+
+Conflicter.prototype.add = function add(conflict) {
   if (typeof conflict === 'string') {
     conflict = {
       file: conflict,
@@ -34,47 +36,47 @@ conflicter.add = function add(conflict) {
   return this;
 };
 
-conflicter.reset = function reset() {
+Conflicter.prototype.reset = function reset() {
   this.conflicts = [];
   return this;
 };
 
-conflicter.pop = function pop() {
+Conflicter.prototype.pop = function pop() {
   return this.conflicts.pop();
 };
 
-conflicter.shift = function shift() {
+Conflicter.prototype.shift = function shift() {
   return this.conflicts.shift();
 };
 
-conflicter.resolve = function resolve(cb) {
+Conflicter.prototype.resolve = function resolve(cb) {
   var resolveConflicts = function (conflict) {
     return function (next) {
       if (!conflict) {
         return next();
       }
 
-      conflicter.collision(conflict.file, conflict.content, function (status) {
-        conflicter.emit('resolved:' + conflict.file, {
+      this.collision(conflict.file, conflict.content, function (status) {
+        this.emit('resolved:' + conflict.file, {
           status: status,
           callback: next
         });
-      });
-    };
-  };
+      }.bind(this));
+    }.bind(this);
+  }.bind(this);
 
   async.series(this.conflicts.map(resolveConflicts), function (err) {
     if (err) {
       cb();
-      return self.emit('error', err);
+      return this.emit('error', err);
     }
 
-    conflicter.reset();
+    this.reset();
     cb();
   }.bind(this));
 };
 
-conflicter._ask = function (filepath, content, cb) {
+Conflicter.prototype._ask = function (filepath, content, cb) {
   // for this particular use case, might use prompt module directly to avoid
   // the additional "Are you sure?" prompt
 
@@ -88,21 +90,21 @@ conflicter._ask = function (filepath, content, cb) {
       key: 'y',
       name: 'overwrite',
       value: function (cb) {
-        log.force(rfilepath);
+        self.adapter.log.force(rfilepath);
         return cb('force');
       }
     }, {
       key: 'n',
       name: 'do not overwrite',
       value: function (cb) {
-        log.skip(rfilepath);
+        self.adapter.log.skip(rfilepath);
         return cb('skip');
       }
     }, {
       key: 'a',
       name: 'overwrite this and all others',
       value: function (cb) {
-        log.force(rfilepath);
+        self.adapter.log.force(rfilepath);
         self.force = true;
         return cb('force');
       }
@@ -110,14 +112,14 @@ conflicter._ask = function (filepath, content, cb) {
       key: 'x',
       name: 'abort',
       value: function (cb) {
-        log.writeln('Aborting ...');
+        self.adapter.log.writeln('Aborting ...');
         return process.exit(0);
       }
     }, {
       key: 'd',
       name: 'show the differences between the old and the new',
       value: function (cb) {
-        console.log(conflicter.diff(fs.readFileSync(filepath, 'utf8'), content));
+        self.diff(fs.readFileSync(filepath, 'utf8'), content);
         return self._ask(filepath, content, cb);
       }
     }],
@@ -129,19 +131,18 @@ conflicter._ask = function (filepath, content, cb) {
     this.emit('conflict', filepath);
   }.bind(this));
 
-  prompt(config, function (result) {
+  this.adapter.prompt(config, function (result) {
     result.overwrite(function (action) {
       cb(action);
     });
   });
 };
 
-conflicter.collision = function collision(filepath, content, cb) {
-  var self = this;
-  var rfilepath = path.relative(process.cwd(), path.resolve(filepath));
 
+Conflicter.prototype.collision = function collision(filepath, content, cb) {
+  var rfilepath = path.relative(process.cwd(), path.resolve(filepath));
   if (!fs.existsSync(filepath)) {
-    log.create(rfilepath);
+    this.adapter.log.create(rfilepath);
     return cb('create');
   }
 
@@ -159,52 +160,23 @@ conflicter.collision = function collision(filepath, content, cb) {
     //
     // For not binary content, we can directly compare the 2 strings this way
     if ((!encoding && (actual.toString('hex') === content.toString('hex'))) ||
-    (actual === content)) {
-      log.identical(rfilepath);
+      (actual === content)) {
+      this.adapter.log.identical(rfilepath);
       return cb('identical');
     }
   }
 
-  if (self.force) {
-    log.force(rfilepath);
+  if (this.force) {
+    this.adapter.log.force(rfilepath);
     return cb('force');
   }
 
-  log.conflict(rfilepath);
-  conflicter._ask(filepath, content, cb);
+  this.adapter.log.conflict(rfilepath);
+  this._ask(filepath, content, cb);
 };
 
-conflicter.colorDiffAdded = chalk.black.bgGreen;
-conflicter.colorDiffRemoved = chalk.bgRed;
 
 // below is borrowed code from visionmedia's excellent mocha (and its reporter)
-conflicter.diff = function _diff(actual, expected) {
-  var msg = diff.diffLines(actual, expected).map(function (str) {
-    if (str.added) {
-      return conflicter.colorLines('Added', str.value);
-    }
-
-    if (str.removed) {
-      return conflicter.colorLines('Removed', str.value);
-    }
-
-    return str.value;
-  }).join('');
-
-  // legend
-  msg = '\n' +
-    conflicter.colorDiffRemoved('removed') +
-    ' ' +
-    conflicter.colorDiffAdded('added') +
-    '\n\n' +
-    msg +
-    '\n';
-
-  return msg;
-};
-
-conflicter.colorLines = function colorLines(name, str) {
-  return str.split('\n').map(function (str) {
-    return conflicter['colorDiff' + name](str);
-  }).join('\n');
+Conflicter.prototype.diff = function _diff(actual, expected) {
+  return this.adapter.diff(actual, expected);
 };

--- a/main.js
+++ b/main.js
@@ -1,5 +1,3 @@
-process.logging = process.logging || require('./lib/util/log');
-
 // The generator system is a framework for node to author reusable and
 // composable Generators, for a vast majority of use-case.
 //
@@ -24,9 +22,8 @@ process.logging = process.logging || require('./lib/util/log');
 // node_modules/yeoman-backbone/lib/generators)
 
 var Environment = require('./lib/env');
-
-var generators = module.exports = function createEnv(args, opts) {
-  return new Environment(args, opts);
+var generators = module.exports = function createEnv(args, opts, adapter) {
+  return new Environment(args, opts, adapter);
 };
 
 // Reference general dependencies on the top level object

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -1,0 +1,105 @@
+/*global describe, before, beforeEach, afterEach, it */
+var TerminalAdapter = require('../lib/env/adapter');
+var assert = require('assert');
+var sinon = require('sinon');
+var inquirer = require('inquirer');
+var helpers = require('..').test;
+
+describe('TerminalAdapter', function () {
+  'use strict';
+
+  beforeEach(function () {
+    this.adapter = new TerminalAdapter();
+  });
+
+  describe('#prompt', function () {
+    beforeEach(function () {
+      this.spy = sinon.spy(inquirer, 'prompt');
+    });
+
+    afterEach(function () {
+      inquirer.prompt.restore();
+    });
+
+    it('pass its arguments to inquirer', function () {
+      var questions = [];
+      var cb = function () {};
+      this.adapter.prompt(questions, cb);
+      assert(this.spy.withArgs(questions, cb).calledOnce);
+    });
+  });
+
+  describe('#diff', function () {
+    it('returns properly colored diffs', function () {
+      var diff = this.adapter.diff('var', 'let');
+      helpers.assertTextEqual(diff, '\n\u001b[41mremoved\u001b[49m \u001b[42m\u001b[30madded\u001b[39m\u001b[49m\n\n\u001b[42m\u001b[30mlet\u001b[39m\u001b[49m\u001b[41mvar\u001b[49m\n');
+    });
+  });
+
+  describe('#log function', function () {
+    beforeEach(function () {
+      this.spyerror = sinon.spy(console, 'error');
+    });
+
+    afterEach(function () {
+      console.error.restore();
+    });
+
+    it('calls console.error and perform strings interpolation', function () {
+      this.adapter.log('%has %many %reps', {
+        has: 'has',
+        many: 'many',
+        reps: 'reps'
+      });
+      assert(this.spyerror.withArgs('has many reps').calledOnce);
+    });
+  });
+
+  describe('#log object', function () {
+
+    beforeEach(function () {
+      this.spylog = sinon.spy(process.stderr, 'write');
+    });
+
+    afterEach(function () {
+      process.stderr.write.restore();
+    });
+
+    it('#write pass strings as they are', function () {
+      var testString = 'dummy';
+      this.adapter.log.write(testString);
+      assert(this.spylog.withArgs(testString).calledOnce);
+    });
+
+    it('#write accepts utile#format style arguments', function () {
+      this.adapter.log.write('A number: %d, a string: %s', 1, 'bla');
+      assert(this.spylog.withArgs('A number: 1, a string: bla').calledOnce);
+    });
+
+    it('#writeln adds a \\n at the end', function () {
+      this.adapter.log.writeln('dummy');
+      assert(this.spylog.withArgs('dummy').calledOnce);
+      assert(this.spylog.withArgs('\n').calledOnce);
+    });
+
+    it('#ok adds a green "✔ " at the beginning and \\n at the end', function () {
+      this.adapter.log.ok('dummy');
+      assert(this.spylog.withArgs('\u001b[32m✔ \u001b[39mdummy\n').calledOnce);
+    });
+
+    it('#error adds a green "✗ " at the beginning and \\n at the end', function () {
+      this.adapter.log.error('dummy');
+      assert(this.spylog.withArgs('\u001b[31m✗ \u001b[39mdummy\n').calledOnce);
+    });
+
+    describe('statuses', function () {
+      it('#skip');
+      it('#force');
+      it('#create');
+      it('#invoke');
+      it('#conflict');
+      it('#identical');
+      it('#info');
+    });
+  });
+});

--- a/test/env.js
+++ b/test/env.js
@@ -7,7 +7,7 @@ var sinon = require('sinon');
 var generators = require('..');
 var helpers = generators.test;
 var events = require('events');
-
+var TerminalAdapter = require('../lib/env/adapter');
 var Base = generators.Base;
 var Environment = require('../lib/env');
 var Store = require('../lib/env/store');
@@ -64,6 +64,16 @@ describe('Environment', function () {
       this.expected = this.expected.replace('Usage: init', 'Usage: gg');
       helpers.assertTextEqual(this.env.help('gg').trim(), this.expected);
     });
+    it('instantiates a TerminalAdapter if none provided', function () {
+      assert.ok(this.env.adapter instanceof TerminalAdapter, 'Not a TerminalAdapter');
+    });
+
+    it('uses the provided object as adapter if any', function () {
+      var dummyAdapter = {};
+      var env = new Environment(null, null, dummyAdapter);
+      assert.equal(env.adapter, dummyAdapter, 'Not the adapter provided');
+    });
+
   });
 
   describe('#create', function () {

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -49,7 +49,11 @@ describe('generators.Base fetch utilities', function () {
       this.events = new events.EventEmitter();
       this.download = sinon.stub().returns(this.events);
       this.fetch = proxyquire('../lib/actions/fetch', { download: this.download });
-      this.fetch.log = { write: noop, info: noop, ok: noop };
+      this.fetch.log = {
+        write: noop,
+        info: noop,
+        ok: noop
+      };
     });
 
     it('download and untar via the NPM download package', function (done) {


### PR DESCRIPTION
This PR refers to #369

I'd like to have some feedback, especially your consideration on how to handle conflicts
- [x] Make `Base.prototype.prompt` calla `adapter.prompt`
- [x] Register a default `TerminalAdapter` to handle CLI interaction
- [x] Adapt tests for Base.prototype.prompt
- [x] Add tests for `TerminalAdapter`
- [x] Define interaction for `conflicter` (`conflict` event? `diff` event? make conflicter a class and pass the adapter?)
- [x] Implement and test this interaction
