### PR TITLE
Add hide option to hookFor

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -355,9 +355,10 @@ Base.prototype.runHooks = function runHooks(cb) {
  *
  * @param {String} name
  * @param {Object} config
+ * @param {Boolean} hide
  */
 
-Base.prototype.hookFor = function hookFor(name, config) {
+Base.prototype.hookFor = function hookFor(name, config, hide) {
   config = config || {};
 
   // enforce use of hookFor during instantiation
@@ -371,7 +372,8 @@ Base.prototype.hookFor = function hookFor(name, config) {
   // in help
   this.option(name, {
     desc: this._.humanize(name) + ' to be invoked',
-    defaults: this.options[name] || ''
+    defaults: this.options[name] || '',
+    hide: hide
   });
 
   this._hooks.push(_.defaults(config, {


### PR DESCRIPTION
Hides a hook from the help menu when it is passed true for the hide option.

Some hooks perform additional actions and shouldn't be shown on the menu
