### PR TITLE
Help improvements

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -207,7 +207,11 @@ Base.prototype.argument = function argument(name, config) {
   var value = config.type === Array ? this.args.slice(position) : this.args[position];
   value = position >= this.args.length ? config.defaults : value;
 
-  if (config.required && value === undefined) {
+  // If the help option was provided, we don't want to check for required arguments,
+  // since we're only going to print the help message anyway.
+  // If the help option was not provided, check whether the argument was required,
+  // and whether a value was provided.
+  if (!this.options.help && config.required && value === undefined) {
     return this.emit('error', new Error('Did not provide required argument ' + chalk.bold(name) + '!'));
   }
 
@@ -447,6 +451,15 @@ Base.prototype.help = function help() {
     ]);
   }
 
+  // build arguments
+  if (this._arguments.length) {
+    out = out.concat([
+      'Arguments:',
+      this.argumentsHelp(),
+      ''
+    ]);
+  }
+
   // append USAGE file is any
   if (exists) {
     out.push(fs.readFileSync(filepath, 'utf8'));
@@ -462,11 +475,17 @@ Base.prototype.help = function help() {
 
 Base.prototype.usage = function usage() {
   var options = this._options.length ? '[options]' : '';
-  var name = this.generatorName ? ' ' + this.generatorName : '';
+  var name = ' ' + this.options.namespace;
+
+  var arguments = '';
+
+  if (this._arguments.length) {
+    arguments = this._arguments.map(formatArg).join(' ');
+  }
 
   name = name.replace(/^yeoman:/, '');
 
-  var out = 'yo' + name + ' ' + options;
+  var out = 'yo' + name + ' ' + options + ' ' + arguments;
 
   if (this.description) {
     out += '\n\n' + this.description;
@@ -474,6 +493,16 @@ Base.prototype.usage = function usage() {
 
   return out;
 };
+
+function formatArg(argItem) {
+  var arg = '<' + argItem.name + '>';
+
+  if (!argItem.config.required) {
+    arg = '[' + arg + ']';
+  }
+
+  return arg;
+}
 
 /**
  * Simple setter for custom `description` to append on help output.
@@ -484,6 +513,22 @@ Base.prototype.usage = function usage() {
 Base.prototype.desc = function desc(description) {
   this.description = description || '';
   return this;
+};
+
+
+Base.prototype.argumentsHelp = function argumentsHelp() {
+  var rows = this._arguments.map(function(a) {
+    return [
+      '',
+      a.name ? a.name : '',
+      a.config.type ? '# Type: ' + a.config.type.name : '',
+      'Required: ' + a.config.required
+    ];
+  });
+
+  return this.log.table({
+    rows: rows
+  });
 };
 
 /**

--- a/lib/env/index.js
+++ b/lib/env/index.js
@@ -311,6 +311,7 @@ Environment.prototype.create = function create(namespace, options) {
   opts.env = this;
   opts.name = name;
   opts.resolved = Generator.resolved;
+  opts.namespace = namespace;
   return new Generator(args, opts);
 };
 

--- a/test/base.js
+++ b/test/base.js
@@ -34,6 +34,7 @@ describe('yeoman.generators.Base', function () {
       something: 'else',
       // mandatory options, created by the env#create() helper
       resolved: 'ember:all',
+      namespace: 'dummy',
       env: env,
     });
 
@@ -206,6 +207,21 @@ describe('yeoman.generators.Base', function () {
         required: true
       });
     });
+
+    it('should not raise an error if required arguments are not provided, but the help option has been specified', function () {
+      var dummy = new generators.Base([], {
+        env: this.env,
+        resolved: 'dummy:all'
+      });
+
+      dummy.options.help = true;
+
+      assert.equal(dummy._arguments.length, 0);
+
+      assert.doesNotThrow(dummy.argument.bind(dummy, 'foo', {required: true}));
+
+      assert.equal(dummy._arguments.length, 1);
+    });
   });
 
   describe('generator.option(name, config)', function () {
@@ -274,26 +290,42 @@ describe('yeoman.generators.Base', function () {
   describe('generator.help()', function () {
     it('should return the expected help / usage output', function () {
       this.dummy.option('ooOoo');
+      this.dummy.argument('baz', {
+        type: Number,
+        required: false
+      });
       var help = this.dummy.help();
 
       assert.ok(help.match('Usage:'));
-      assert.ok(help.match('yo \\[options\\]'));
+      assert.ok(help.match('yo dummy \\[options\\] <foo> <bar> \\[<baz>\\]'));
       assert.ok(help.match('A new desc for this generator'));
       assert.ok(help.match('Options:'));
       assert.ok(help.match('--help   # Print generator\'s options and usage'));
       assert.ok(help.match('--ooOoo  # Description for ooOoo'));
+      assert.ok(help.match('Arguments:'));
+      assert.ok(help.match('foo  # Type: String  Required: true'));
+      assert.ok(help.match('bar  # Type: Array   Required: true'));
+      assert.ok(help.match('baz  # Type: Number  Required: false'));
     });
   });
 
   describe('generator.usage()', function () {
-    it('should return the expected help / usage output', function () {
+    it('should return the expected help / usage output with arguments', function () {
       var usage = this.dummy.usage();
-      assert.equal(usage, 'yo [options]\n\nA new desc for this generator');
+      assert.equal(usage, 'yo dummy [options] <foo> <bar> [<baz>]\n\nA new desc for this generator');
     });
 
-    it('should use the provided generatorName', function() {
-      this.dummy.generatorName = 'dummy';
-      assert.ok(this.dummy.usage().match('yo dummy'));
+    it('should return the expected help / usage output without arguments', function () {
+      this.dummy._arguments.length = 0;
+      var usage = this.dummy.usage();
+      assert.equal(usage, 'yo dummy [options] \n\nA new desc for this generator');
+    });
+
+    it('should return the expected help / usage output without options', function () {
+      this.dummy._arguments.length = 0;
+      this.dummy._options.length = 0;
+      var usage = this.dummy.usage();
+      assert.equal(usage, 'yo dummy  \n\nA new desc for this generator');
     });
   });
 

--- a/test/env.js
+++ b/test/env.js
@@ -138,6 +138,37 @@ describe('Environment', function () {
     it('add the Generator resolved path on the options', function() {
       assert.equal(this.env.create('stub').options.resolved, this.env.get('stub').resolved);
     });
+
+    it('adds the namespace on the options', function() {
+      assert.equal(this.env.create('stub').options.namespace, 'stub');
+    });
+
+    it('adds the namespace as called on the options', function() {
+      assert.equal(this.env.create('stub:foo:bar').options.namespace, 'stub:foo:bar');
+    });
+
+    describe('NamedBase', function () {
+      beforeEach(function () {
+        this.env.register('./fixtures/custom-generator-extend', 'scaffold');
+
+        this.NamedGenerator = this.env.get('scaffold');
+      });
+
+      it('does not raise an error when the help option is provided but the required name parameter is not', function () {
+        assert.doesNotThrow(this.env.create.bind(this.env, 'scaffold', { options: { help: true } }));
+      });
+
+      it('calls the named base generator with the help option and provides the required name parameter', function () {
+        var generator = this.env.create('scaffold', { args: [ 'foo' ], options: { help: true } });
+
+        assert.equal(generator.options.help, true);
+        assert.equal(generator.name, 'foo');
+      });
+
+      it('throws an error when the required name parameter is not provided', function () {
+        assert.throws(this.env.create.bind(this.env, 'scaffold'));
+      });
+    });
   });
 
   describe('#run', function () {


### PR DESCRIPTION
Previously, running something like `yo angular:directive --help` would only show an error due to the missing required _name_ argument. This was not very helpful for the user.

I’ve changed this so that when providing the help option, the required arguments are added, but no error is raised if a required argument is not provided. This results in a clean and consistent handling of the help option. Now when running `yo angular:directive --help`, the standard help/usage screen is shown, listing the options and arguments.

In addition to that, I’ve enhanced the help/usage function to list the arguments both in the usage line and also as an additional table similar to the options table. Let me know if that format looks good, I tried to keep it similar to the format used by the options.

As a byproduct, I had to add the _namespace_ to the _options_ object in `env.create`, since it’s used for displaying the correct name of the generator in the usage line. With the previous version, a call to `yo angular:directive --help` resulted in the usage line `yo directive`. Using the namespace in this place ensures that the correct name is displayed in the usage line: `yo angular:directive`.
