### PR TITLE
Use a text color of black to make diff readable

### DIFF
--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -172,7 +172,7 @@ conflicter.collision = function collision(filepath, content, cb) {
   conflicter._ask(filepath, content, cb);
 };
 
-conflicter.colorDiffAdded = chalk.bgGreen;
+conflicter.colorDiffAdded = chalk.black.bgGreen;
 conflicter.colorDiffRemoved = chalk.bgRed;
 
 // below is borrowed code from visionmedia's excellent mocha (and its reporter)

--- a/test/conflicter.js
+++ b/test/conflicter.js
@@ -114,7 +114,7 @@ describe('conflicter', function () {
 
   it('conflicter#diff(actual, expected)', function () {
     var diff = conflicter.diff('var', 'let');
-    assert.equal(diff, '\n\u001b[41mremoved\u001b[49m \u001b[42madded\u001b[49m\n\n\u001b[42mlet\u001b[49m\u001b[41mvar\u001b[49m\n');
+    assert.equal(diff, '\n\u001b[41mremoved\u001b[49m \u001b[42m\u001b[30madded\u001b[39m\u001b[49m\n\n\u001b[42m\u001b[30mlet\u001b[39m\u001b[49m\u001b[41mvar\u001b[49m\n');
   });
 
   describe('conflicter#_ask', function () {


### PR DESCRIPTION
Pretty simple. Add .black to text to make it legible.

Example before:
![screen shot 2013-11-08 at 12 46 37 pm](https://f.cloud.github.com/assets/525011/1502633/bccb4af8-489d-11e3-96c7-2beecee15762.png)

Example after:
![screen shot 2013-11-08 at 8 39 14 pm](https://f.cloud.github.com/assets/525011/1505630/e6c67c3c-48df-11e3-9a3b-285e507119d9.png)

Example after on light background:
![screen shot 2013-11-08 at 8 41 01 pm](https://f.cloud.github.com/assets/525011/1505631/0f9b0128-48e0-11e3-8b56-defae5fdcb25.png)

closes #397 
