### PR TITLE
For conflicts where the filepath is '.', print the directory instead of just dot

### DIFF
--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -78,6 +78,10 @@ conflicter._ask = function (filepath, content, cb) {
   // for this particular use case, might use prompt module directly to avoid
   // the additional "Are you sure?" prompt
 
+  if (filepath == '.') {
+    filepath = path.basename(path.resolve(path.dirname(filepath)));
+  }
+
   var self = this;
 
   var config = [{
@@ -168,7 +172,11 @@ conflicter.collision = function collision(filepath, content, cb) {
     return cb('force');
   }
 
-  log.conflict(filepath);
+  if (filepath == '.') {
+	  log.conflict(path.basename(path.resolve(path.dirname(filepath))));
+  } else {
+	  log.conflict(filepath);
+  }
   conflicter._ask(filepath, content, cb);
 };
 


### PR DESCRIPTION
What do you guys think about this?
