### PR TITLE
Resolve destinationRoot in prepCopy.

### DIFF
--- a/lib/actions/actions.js
+++ b/lib/actions/actions.js
@@ -83,6 +83,7 @@ function prepCopy(source, destination, process) {
   }
 
   source = this.isPathAbsolute(source) ? source : path.join(this.sourceRoot(), source);
+  destination = this.isPathAbsolute(destination) ? destination : path.join(this.destinationRoot(), destination);
 
   var encoding = null;
   var binary = isBinaryFile(source);
@@ -119,7 +120,7 @@ function prepCopy(source, destination, process) {
 actions.copy = function copy(source, destination, process) {
 
   var file = prepCopy.call(this, source, destination, process);
- 
+
   try {
     file.body = this.engine(file.body, this);
   } catch (err) {

--- a/test/actions.js
+++ b/test/actions.js
@@ -77,11 +77,20 @@ describe('yeoman.generators.Base', function () {
 
         return contents;
       });
+
+      var oldDestRoot = this.dummy.destinationRoot();
+      this.dummy.destinationRoot('write/to');
+      this.dummy.copy('foo.js', 'foo-destRoot.js');
+      this.dummy.destinationRoot(oldDestRoot);
       this.dummy.conflicter.resolve(done);
     });
 
     it('should copy source files relative to the "sourceRoot" value', function (done) {
       fs.stat('write/to/foo.js', done);
+    });
+
+    it('should copy to destination files relative to the "destinationRoot" value', function (done) {
+      fs.stat('write/to/foo-destRoot.js', done);
     });
 
     it('should allow absolute path, and prevent the relative paths join', function (done) {


### PR DESCRIPTION
This improves the configurability of generator subclasses with non-standard `destinationRoot`s.

Currently, `prepCopy` resolves the `source` argument against the Generator's configurable `sourceRoot`. This commit adds the same behaviour to `destination` and `destinationRoot`, respectively.
