### PR TITLE
Adding failing tests for end event firing multiple times when copying a file more than once.

### DIFF
--- a/lib/actions/actions.js
+++ b/lib/actions/actions.js
@@ -119,7 +119,7 @@ function prepCopy(source, destination, process) {
 actions.copy = function copy(source, destination, process) {
 
   var file = prepCopy.call(this, source, destination, process);
- 
+
   try {
     file.body = this.engine(file.body, this);
   } catch (err) {
@@ -290,7 +290,9 @@ actions.checkForCollision = function checkForCollision(filepath, content, cb) {
     content: content
   });
 
-  this.conflicter.once('resolved:' + filepath, cb.bind(this, null));
+  this.conflicter.once('resolved:' + filepath, function (config) {
+    process.nextTick(cb.bind(this, null, config));
+  }.bind(this));
 };
 
 /**

--- a/test/env.js
+++ b/test/env.js
@@ -501,6 +501,38 @@ describe('Environment', function () {
         // actual run
         .run('angular:all myapp');
     });
+
+    it('only call the end event once (bug #402)', function (done) {
+      function GeneratorOnce() {
+        generators.Base.apply(this, arguments);
+        this.sourceRoot(path.join(__dirname, 'fixtures'));
+        this.destinationRoot(path.join(__dirname, 'temp'));
+      }
+
+      util.inherits(GeneratorOnce, generators.Base);
+
+      GeneratorOnce.prototype.createDuplicate = function () {
+        this.copy('foo-copy.js');
+        this.copy('foo-copy.js');
+      };
+
+      var generatorOnce = new GeneratorOnce([], {
+        env: generators(),
+        resolved: __filename
+      });
+
+      var isFirstEndEvent = true;
+
+      generatorOnce.on('end', function () {
+        assert.ok(isFirstEndEvent);
+        if (isFirstEndEvent) {
+          done();
+        }
+        isFirstEndEvent = false;
+      });
+
+      generatorOnce.run();
+    });
   });
 
   describe('Store', function() {


### PR DESCRIPTION
Here is a failing test illustrating the issue in #302.

I think this is related to using the filename as part of the event name when [added to the conflicter](https://github.com/yeoman/generator/blob/c57e4e10ecc63535dc97fb40db0f51ac0f807b42/lib/actions/actions.js#L287-L294) and [resolving the conflict](https://github.com/yeoman/generator/blob/c57e4e10ecc63535dc97fb40db0f51ac0f807b42/lib/util/conflicter.js#L58-L61).
