### PR TITLE
Recombine `sourceRoot` and `destinationRoot` logic

### DIFF
--- a/lib/actions/actions.js
+++ b/lib/actions/actions.js
@@ -16,46 +16,6 @@ var actions = module.exports;
 actions.log = log;
 
 /**
- * Stores and return the source root for this class. The source root is used to
- * prefix filepath with `.read()` or `.template()`.
- *
- * @param {String} root
- */
-
-actions.sourceRoot = function sourceRoot(root) {
-  if (root) {
-    this._sourceRoot = path.resolve(root);
-  }
-
-  return this._sourceRoot;
-};
-
-/**
- * Sets the destination root for this class, the working directory. Relative
- * path are added to the directory where the script was invoked and
- * expanded.
- *
- * This automatically creates the working directory if it doensn't exists and
- * `cd` into it.
- *
- * @param {String} root
- */
-
-actions.destinationRoot = function destinationRoot(root) {
-  if (root) {
-    this._destinationRoot = path.resolve(root);
-
-    if (!fs.existsSync(root)) {
-      this.mkdir(root);
-    }
-
-    process.chdir(root);
-  }
-
-  return this._destinationRoot || './';
-};
-
-/**
  * Stores and return the cache root for this class. The cache root is used to
  * `git clone` repositories from github by `.remote()` for example.
  */

--- a/lib/base.js
+++ b/lib/base.js
@@ -11,7 +11,6 @@ var file = require('file-utils');
 var engines = require('./util/engines');
 var conflicter = require('./util/conflicter');
 var Storage = require('./util/storage');
-var actions = require('./actions/actions');
 
 var noop = function () {};
 var fileLogger = { write: noop, warn: noop };
@@ -87,8 +86,6 @@ var Base = module.exports = function Base(args, options) {
   this._conflicts = [];
   this.appname = path.basename(process.cwd()).replace(/[^\w\s]+?/g, ' ');
 
-  this._setStorage();
-
   this.option('help', {
     alias: 'h',
     desc: 'Print generator\'s options and usage'
@@ -110,14 +107,16 @@ var Base = module.exports = function Base(args, options) {
   this.dest.registerValidationFilter('collision', this.getCollisionFilter());
   this.src.registerValidationFilter('collision', this.getCollisionFilter());
 
+  this._setStorage();
+
   // ensure source/destination path, can be configured from subclasses
   this.sourceRoot(path.join(path.dirname(this.resolved), 'templates'));
 };
 
 util.inherits(Base, events.EventEmitter);
 
-// "include" the actions modules
-_.extend(Base.prototype, actions);
+// Mixin the actions modules
+_.extend(Base.prototype, require('./actions/actions'));
 _.extend(Base.prototype, require('./actions/fetch'));
 _.extend(Base.prototype, require('./actions/file'));
 _.extend(Base.prototype, require('./actions/install'));
@@ -599,50 +598,57 @@ Base.prototype.rootGeneratorName = function () {
  */
 
 Base.prototype._setStorage = function () {
-  var storePath = path.join(actions.destinationRoot.call(this), '.yo-rc.json');
+  var storePath = path.join(this.destinationRoot(), '.yo-rc.json');
   this.config = new Storage(this.rootGeneratorName(), storePath);
 };
 
 /**
  * Change the generator destination root directory.
- * This method façade the lib/actions/actions.js method so it can update the storage and
- * the file-utils environments.
+ * This path is used to find storage, when using `this.dest` and `this.src` and for
+ * multiple file actions (like `this.write` and `this.copy`)
  * @param  {String} rootPath new destination root path
  * @return {String}          destination root path
  */
 
 Base.prototype.destinationRoot = function (rootPath) {
-  var root = actions.destinationRoot.call(this, rootPath);
-
   if (_.isString(rootPath)) {
+    this._destinationRoot = path.resolve(rootPath);
+
+    if (!fs.existsSync(rootPath)) {
+      this.mkdir(rootPath);
+    }
+
+    process.chdir(rootPath);
+
+    // Reset the storage
     this._setStorage();
 
     // Update file helpers path bases
-    this.dest.setBase(root);
-    this.src.setDestBase(root);
+    this.dest.setBase(this._destinationRoot);
+    this.src.setDestBase(this._destinationRoot);
   }
 
-  return root;
+  return this._destinationRoot || './';
 };
 
 /**
  * Change the generator source root directory.
- * This method façade the lib/actions/actions.js method so it can update the
- * file-utils environments.
+ * This path is used by `this.dest` and `this.src` and multiples file actions like
+ * (`this.read` and `this.copy`)
  * @param  {String} rootPath new source root path
  * @return {String}          source root path
  */
 
 Base.prototype.sourceRoot = function (rootPath) {
-  var root = actions.sourceRoot.call(this, rootPath);
-
   if (_.isString(rootPath)) {
+    this._sourceRoot = path.resolve(rootPath);
+
     // Update file helpers path bases
-    this.src.setBase(root);
-    this.dest.setDestBase(root);
+    this.src.setBase(this._sourceRoot);
+    this.dest.setDestBase(this._sourceRoot);
   }
 
-  return root;
+  return this._sourceRoot;
 };
 
 


### PR DESCRIPTION
And fixes a warning error from Node.js 0.10.x (one of the lastest warns if you use `process.nextTick`)
