### PR TITLE
Fixed RangeError: Maximum call stack size exceeded for Windows

### DIFF
--- a/lib/env/resolver.js
+++ b/lib/env/resolver.js
@@ -210,7 +210,7 @@ exports.plugins = function plugins(filename, basedir) {
   // file name is case insensitive on Windows
   if (basedir === rootdir ||
       process.platform === 'win32' &&
-      basedir.toLowerCase() === rootdir.toLowerCase())
+      basedir.toLowerCase() === rootdir.toLowerCase()) {
     return this;
   }
 


### PR DESCRIPTION
The same issue was posted and discussed in [google maillist](https://groups.google.com/forum/#!msg/yeoman-dev/TveRxapwM0U/KEvzulKkQ6oJ), but not fixed.
**Root cause:** file name on Windows is case insensitive.
