### PR TITLE
Ensure relatives path when resolving conflicts

### DIFF
--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -78,6 +78,8 @@ conflicter._ask = function (filepath, content, cb) {
   // for this particular use case, might use prompt module directly to avoid
   // the additional "Are you sure?" prompt
 
+  filepath = path.relative(process.cwd(), path.resolve(filepath));
+
   var self = this;
 
   var config = [{


### PR DESCRIPTION
A cosmetic issue bringed up in #378.

I'm just unsure this is the correct behavior, and I'm unsure there's any correct behavior aside absolute paths.

Should it really be based on the current working directory? (this one can be changed by Node.js, but it feels like the closest to want we want)
