### PR TITLE
Added doc information clarifying options property used on hookFor method...

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -369,13 +369,23 @@ Base.prototype.runHooks = function runHooks(cb) {
  *
  *   - `as` The context value to use when runing the hooked generator
  *   - `args` The array of positional arguments to init and run the generator with
- *   - `options` The hash of options to use to init and run the generator with
+ *   - `options` An object containing a nested `options` property with the hash of options to use to init and run the generator with
  *
  * ### Examples:
  *
  *     // $ yo webapp --test-framework jasmine
  *     this.hookFor('test-framework');
  *     // => registers the `jasmine` hook
+ *
+ *     // $ yo mygen:subgen --myargument
+ *     this.hookFor('mygen', {
+ *       as: 'subgen',
+ *       options: {
+ *         options: {
+ *           'myargument': true
+ *         }
+ *       }
+ *     }
  *
  * @param {String} name
  * @param {Object} config


### PR DESCRIPTION
Just fixed the line on doc clarifying the nested `options.options` object required by `hookFor` method and added a small example of using.

This isn't really a fix to #214, but at least it should explicit the correct use of it.
