### PR TITLE
Store independant Generators' meta data

### DIFF
--- a/lib/env/index.js
+++ b/lib/env/index.js
@@ -245,10 +245,20 @@ Environment.prototype.registerStub = function registerStub(Generator, namespace)
 
 /**
  * Returns the list of registered namespace.
+ * @return {Array}
  */
 
 Environment.prototype.namespaces = function namespaces() {
   return this.store.namespaces();
+};
+
+/**
+ * Returns stored generators meta
+ * @return {Object}
+ */
+
+Environment.prototype.getGeneratorsMeta = function getGeneratorsMeta() {
+  return this.store.getGeneratorsMeta();
 };
 
 /**

--- a/lib/env/store.js
+++ b/lib/env/store.js
@@ -8,7 +8,8 @@ var _ = require('lodash');
  */
 
 var Store = module.exports = function Store () {
-  this._byNamespace = {};
+  this._generators = {};
+  this._meta = {};
 };
 
 /**
@@ -26,22 +27,28 @@ Store.prototype.add = function add (namespace, generator) {
 };
 
 Store.prototype._storeAsPath = function _storeAsPath (namespace, path) {
-  Object.defineProperty(this._byNamespace, namespace, {
+  var meta = {
+    resolved: path,
+    namespace: namespace
+  };
+  this._meta[namespace] = meta;
+  Object.defineProperty(this._generators, namespace, {
     get: function () {
       var Generator = require(path);
-      Generator.resolved = path;
-      Generator.namespace = namespace;
-      return Generator;
+      return _.extend(Generator, meta);
     },
     enumerable: true,
     configurable: true
   });
 };
 
-Store.prototype._storeAsModule = function _storeAsModule (namespace, func) {
-  this._byNamespace[namespace] = func;
-  func.resolved = "unknown";
-  func.namespace = namespace;
+Store.prototype._storeAsModule = function _storeAsModule (namespace, Generator) {
+  var meta = {
+    resolved: "unknown",
+    namespace: namespace
+  };
+  this._meta[namespace] = meta;
+  this._generators[namespace] = _.extend(Generator, meta);
 };
 
 /**
@@ -51,7 +58,7 @@ Store.prototype._storeAsModule = function _storeAsModule (namespace, func) {
  */
 
 Store.prototype.get = function get (namespace) {
-  return this._byNamespace[namespace];
+  return this._generators[namespace];
 };
 
 /**
@@ -60,5 +67,14 @@ Store.prototype.get = function get (namespace) {
  */
 
 Store.prototype.namespaces = function namespaces () {
-  return Object.keys(this._byNamespace);
+  return Object.keys(this._generators);
+};
+
+/**
+ * Get the stored generators meta data
+ * @return {Object} Generators metadata
+ */
+
+Store.prototype.getGeneratorsMeta = function getGeneratorsMeta() {
+  return this._meta;
 };


### PR DESCRIPTION
This will help tools using the Yeoman Environment (like yo) to fetch
meta data from stored Generators without having to requiring each one.
(leading to performane improvement for them)

Related to discussion on https://github.com/yeoman/yo/pull/110
