### PR TITLE
Ensure outdated Yo won't break generators (Fix #434)

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -54,6 +54,8 @@ var Base = module.exports = function Base(args, options) {
   this.fallbacks = this.options.generators || this.options.generator || {};
   this.generatorName = this.options.name || '';
 
+  require('./env').enforceUpdate(this.env);
+
   this.description = '';
 
   this.async = function () {

--- a/lib/env/index.js
+++ b/lib/env/index.js
@@ -428,3 +428,17 @@ Environment.prototype.resolveModulePath = function resolveModulePath(moduleId) {
 
   return require.resolve(moduleId);
 };
+
+/**
+ * Make sure the Environment present expected methods if an old version is
+ * passed to a Generator.
+ * @param  {Environment} env
+ * @return {Environment} The updated env
+ */
+
+Environment.enforceUpdate = function (env) {
+  if (!env.adapter) {
+    env.adapter = new TerminalAdapter();
+  }
+  return env;
+};

--- a/test/env.js
+++ b/test/env.js
@@ -499,6 +499,15 @@ describe('Environment', function () {
     });
   });
 
+  describe('.enforceUpdate', function () {
+    it('add an adapter', function () {
+      var env = new Environment();
+      delete env.adapter;
+      Environment.enforceUpdate(env);
+      assert(env.adapter);
+    });
+  });
+
   // Events
   // ------
 


### PR DESCRIPTION
We now ensure newest methods or properties are available on the env passed to Generators.
