### PR TITLE
Find all node_modules directories, not only nearest to root

### DIFF
--- a/lib/env/resolver.js
+++ b/lib/env/resolver.js
@@ -46,18 +46,23 @@ exports.lookup = function () {
 
 exports._getNpmGenerators = function () {
   var modules = [];
-  this.paths
-    .map(function (root) {
-      return findup('node_modules/', { cwd: root });
-    })
-    .forEach(function (root) {
-      if (!root) return;
-      var found = glob.sync('generator-*', { cwd: root, stat: true })
-        .map(function( match ) {
-          return fs.realpathSync(path.join(root, match));
-        });
-      modules = modules.concat(found);
+  var nodeModules = [];
+
+  this.paths.forEach(function (root) {
+    var found = findup('node_modules/', { cwd: root });
+    while (found && found !== path.dirname(found)) {
+      nodeModules.push(found);
+      found = findup('node_modules/', { cwd: path.dirname(path.dirname(found)) });
+    }
+  });
+
+  nodeModules.forEach(function (root) {
+    if (!root) return;
+    var found = glob.sync('generator-*', { cwd: root, stat: true }).map(function (match) {
+      return fs.realpathSync(path.join(root, match));
     });
+    modules = found.concat(modules);
+  });
 
   return modules;
 };

--- a/test/fixtures/lookup-project/subdir/package.json
+++ b/test/fixtures/lookup-project/subdir/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "lookup-subdir-dummy-env",
+  "dependencies": {
+    "generator-dummy": "~0.1.0"
+  }
+}


### PR DESCRIPTION
Findup searches for the first `node_modules` directory in cwd and
it's ancestors, but what if our generators in `~/node_modules`,
and we calling generator in directory, that has `node_modules`?
Right - `yo` will think, that you have 0 generators.

Closes #440
