### PR TITLE
PATH variables splitted by : in unix and can contain ::

### DIFF
--- a/lib/env/index.js
+++ b/lib/env/index.js
@@ -100,7 +100,7 @@ Environment.prototype.appendDefaultPaths = function() {
   // because of bugs in the parseable implementation of `ls` command and mostly
   // performance issues. So, we go with our best bet for now.
   if (process.env.NODE_PATH) {
-    process.env.NODE_PATH.split(/[,;]/g).forEach(this.appendPath, this);
+    _.compact(process.env.NODE_PATH.split(/[;:]/g)).forEach(this.appendPath, this);
     return;
   }
 


### PR DESCRIPTION
In unix PATH variable contains `:` as delimeter, and some scripts
in .bashrc can append empty parts to it.

Related with #444
