### PR TITLE
Make sure helpers.testDirectory don't try to delete CWD

### DIFF
--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -225,7 +225,7 @@ helpers.assertFiles = function (files) {
  * @param  {Regex}        reg      - regex that will be used to search the file
  * @example
  * assertFileContent('models/user.js', /App\.User = DS\.Model\.extend/);
- * 
+ *
  * @also
  *
  * Assert that each file in an array of file-regex pairs matches its corresponding regex
@@ -256,7 +256,7 @@ helpers.assertFileContent = function () {
  * @param  {Regex}        reg      - regex that will be used to search the file
  * @example
  * assertNoFileContent('models/user.js', /App\.User = DS\.Model\.extend/);
- * 
+ *
  * @also
  *
  * Assert that each file in an array of file-regex pairs does not match its corresponding regex
@@ -330,6 +330,10 @@ helpers.testDirectory = function (dir, cb) {
 
   dir = path.resolve(dir);
 
+  // Make sure we're not deleting CWD by moving to top level folder. As we `cd` in the
+  // test dir after cleaning up, this shouldn't be perceivable.
+  process.chdir('/');
+
   rimraf(dir, function (err) {
     if (err) {
       return cb(err);
@@ -376,7 +380,7 @@ helpers.createDummyGenerator = function () {
  *
  * @param {String} name - the name of the generator
  * @param {Array} dependencies - paths to the generators dependencies
- * @param {Array|String} args - arguments to the generator; 
+ * @param {Array|String} args - arguments to the generator;
  *   if String, will be split on spaces to create an Array
  * @param {Object} options - configuration for the generator
  * @example


### PR DESCRIPTION
Deleting CWD is not allowed on Windows, so most chances are this helper was breaking it when used in a `beforeEach` block.

I think this is a good solution, but I'd like your opinions.

Related: https://github.com/yeoman/yeoman/issues/1258
