### PR TITLE
Only match valid character separator in path resolution

### DIFF
--- a/lib/env/index.js
+++ b/lib/env/index.js
@@ -101,7 +101,7 @@ Environment.prototype.appendDefaultPaths = function () {
   // because of bugs in the parseable implementation of `ls` command and mostly
   // performance issues. So, we go with our best bet for now.
   if (process.env.NODE_PATH) {
-    _.compact(process.env.NODE_PATH.split(/[;:]/g)).forEach(this.appendPath, this);
+    _.compact(process.env.NODE_PATH.split(win32 ? ';' : ':')).forEach(this.appendPath, this);
     return;
   }
 

--- a/test/env.js
+++ b/test/env.js
@@ -361,28 +361,39 @@ describe('Environment', function () {
       assert(this.env.paths.indexOf(process.cwd()) >= 0);
     });
 
-    it('append NODE_PATH', function () {
-      process.env.NODE_PATH = '/some/dummy/path';
-      this.env.paths = [];
-      this.env.appendDefaultPaths();
-      assert(this.env.paths.indexOf(path.resolve(process.env.NODE_PATH)) >= 0);
+    describe('with NODE_PATH', function () {
+      beforeEach(function () {
+        process.env.NODE_PATH = '/some/dummy/path';
+        this.env.paths = [];
+        this.env.appendDefaultPaths();
+      });
+
+      it('append NODE_PATH', function () {
+        assert(this.env.paths.indexOf(path.resolve(process.env.NODE_PATH)) >= 0);
+      });
     });
 
-    it('append best bet if NODE_PATH is unset', function () {
-      delete process.env.NODE_PATH;
-      this.env.paths = [];
-      this.env.appendDefaultPaths();
-      assert(this.env.paths.indexOf(this.bestBet) >= 0);
-      assert(this.env.paths.indexOf(this.bestBet2) >= 0);
+    describe('without NODE_PATH', function () {
+      beforeEach(function () {
+        delete process.env.NODE_PATH;
+        this.env.paths = [];
+        this.env.appendDefaultPaths();
+      });
+
+      it('append best bet if NODE_PATH is unset', function () {
+        assert(this.env.paths.indexOf(this.bestBet) >= 0);
+        assert(this.env.paths.indexOf(this.bestBet2) >= 0);
+      });
+
+      it('append default NPM dir depending on your OS', function () {
+        if (process.platform === 'win32') {
+          assert(this.env.paths.indexOf(path.join(process.env.APPDATA, 'npm/node_modules')) >= 0);
+        } else {
+          assert(this.env.paths.indexOf('/usr/lib/node_modules'));
+        }
+      });
     });
 
-    it('append default NPM dir depending on your OS', function () {
-      if (process.platform === 'win32') {
-        assert(this.env.paths.indexOf(path.join(process.env.APPDATA, 'npm/node_modules')) >= 0);
-      } else {
-        assert(this.env.paths.indexOf('/usr/lib/node_modules'));
-      }
-    });
   });
 
   describe('#namespaces', function () {


### PR DESCRIPTION
This cause issues with Windows path where you have a drive name, e.g. C:/etc

Also fixed tests to work on top of expected environement. Some where running but weren't actually testing anything due to environement mis-configuration.

While testing for further bug on Windows, I also realised pr #442 was wrong as it walk up the three of every paths contained while it should only walk up the CWD path. This will need to be fixed too. I'll add a commit for this fix sometime this weekend probably. (or on another commit - either way) - cc @floatdrop
