### PR TITLE
correct assert.noFileContent error msg

### DIFF
--- a/lib/test/assert.js
+++ b/lib/test/assert.js
@@ -167,7 +167,7 @@ assert.noFileContent = function (file, reg) {
     var regex = pair[1];
     assert.file(file);
     var body = fs.readFileSync(file, 'utf8');
-    assert.ok(!regex.test(body), file + ' did not match \'' + regex + '\'.');
+    assert.ok(!regex.test(body), file + ' matched \'' + regex + '\'.');
   });
 };
 


### PR DESCRIPTION
The error message for `assert.noFileContent` was wrong, leading to confusing failed tests.
