### PR TITLE
Refactor the `#run()` methods to use a Queue system

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -313,55 +313,64 @@ Base.prototype.run = function run(args, cb) {
 
   var methods = Object.keys(Object.getPrototypeOf(this));
 
-  var resolve = function (method) {
-    var rules = {
-      underscore: method.charAt(0) !== '_',
-      runnable: _.isFunction(Object.getPrototypeOf(self)[method]),
-      initialize: !/^(constructor|initialize)$/.test(method),
-      valid: function () {
-        return this.underscore && this.initialize && this.runnable;
-      }
-    };
+  if (!methods.length) {
+    throw new Error('This Generator is empty. Add at least one method for it to be runned.');
+  }
 
-    return function (next) {
-      if (!rules.valid()) {
-        return next();
-      }
+  this.env.runLoop.once('end', function () {
+    self.emit('end');
+    cb();
+  });
 
-      var done = function (err) {
-        if (err) {
-          self.emit('error', err);
+  methods
+    .filter(function (name) {
+      var rules = {
+        underscore: name.charAt(0) !== '_',
+        runnable: _.isFunction(Object.getPrototypeOf(self)[name]),
+        initialize: !/^(constructor|initialize)$/.test(name),
+        valid: function () {
+          return this.underscore && this.initialize && this.runnable;
         }
-
-        // resolve file conflicts after every method completes.
-        self.conflicter.resolve(function (err) {
-          if (err) {
-            return self.emit('error', err);
-          }
-
-          next();
-        });
       };
-
-      var running = false;
-      self.async = function () {
-        running = true;
-        return done;
-      };
-
-      self.emit(method);
-      self.emit('method', method);
+      return rules.valid();
+    })
+    .forEach(function (name) {
 
       // Make sure we run the method assigned to the prototype, not an instance value.
-      Object.getPrototypeOf(self)[method].apply(self, args);
+      var method = Object.getPrototypeOf(self)[name];
 
-      if (!running) {
-        done();
-      }
-    };
-  };
+      self.env.runLoop.add(function (completed) {
+        var done = function (err) {
+          if (err) {
+            self.emit('error', err);
+          }
 
-  async.series(methods.map(resolve), this.runHooks.bind(this, cb));
+          // resolve file conflicts after every method completes.
+          self.conflicter.resolve(function (err) {
+            if (err) {
+              return self.emit('error', err);
+            }
+            completed();
+          });
+        };
+
+        var running = false;
+        self.async = function () {
+          running = true;
+          return done;
+        };
+
+        self.emit(name);
+        self.emit('method', name);
+        method.apply(self, args);
+
+        if (!running) {
+          done();
+        }
+      });
+    });
+
+  this.runHooks();
 
   return this;
 };
@@ -376,8 +385,9 @@ Base.prototype.runHooks = function runHooks(cb) {
   var self = this;
   var hooks = this._hooks;
 
+  cb = _.isFunction(cb) ? cb : function () {};
+
   var callback = function (err) {
-    self.emit('end');
     cb(err);
   };
 

--- a/lib/env/index.js
+++ b/lib/env/index.js
@@ -6,6 +6,7 @@ var events = require('events');
 var spawn = require('child_process').spawn;
 var chalk = require('chalk');
 var _ = require('lodash');
+var GroupedQueue = require('grouped-queue');
 
 var debug = require('debug')('generators:environment');
 
@@ -48,6 +49,7 @@ var Environment = module.exports = function Environment(args, opts, adapter) {
   this.adapter = adapter || new TerminalAdapter();
   this.cwd = this.options.cwd || process.cwd();
   this.store = new Store();
+  this.runLoop = new GroupedQueue();
 
   this.lookups = ['.', 'generators', 'lib/generators'];
   this.aliases = [];
@@ -296,10 +298,6 @@ Environment.prototype.run = function run(args, options, done) {
     return generator;
   }
 
-  if (typeof done === 'function') {
-    generator.on('end', done);
-  }
-
   if (options.help) {
     return console.log(generator.help());
   }
@@ -314,7 +312,7 @@ Environment.prototype.run = function run(args, options, done) {
   generator.on('end', this.emit.bind(this, name + ':end'));
   generator.on('end', this.emit.bind(this, 'generators:end'));
 
-  return generator.run();
+  return generator.run(done);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "download": "~0.1.6",
     "request": "~2.30.0",
     "file-utils": "~0.1.1",
-    "class-extend": "~0.1.0"
+    "class-extend": "~0.1.0",
+    "grouped-queue": "~0.1.2"
   },
   "devDependencies": {
     "proxyquire": "~0.5.1",

--- a/test/base.js
+++ b/test/base.js
@@ -195,7 +195,7 @@ describe('yeoman.generators.Base', function () {
       this.TestGenerator.prototype.async1 = function () {
         async1Running = true;
         var done = this.async();
-        setTimeout(function() {
+        setTimeout(function () {
           async1Running = false;
           async1Runned = true;
           done();
@@ -207,6 +207,15 @@ describe('yeoman.generators.Base', function () {
         done();
       };
       this.testGen.run();
+    });
+
+    it('throws if no method is available', function () {
+      var gen = new (yo.generators.Base.extend())([], {
+        resolved: 'generator-ember/all/index.js',
+        namespace: 'dummy',
+        env: this.env
+      });
+      assert.throws(gen.run.bind(gen));
     });
   });
 

--- a/test/env.js
+++ b/test/env.js
@@ -186,13 +186,15 @@ describe('Environment', function () {
   describe('#run()', function () {
     beforeEach(function () {
       var self = this;
-      this.stub = function () {
-        self.args = arguments;
-        Base.apply(this, arguments);
-      };
+      this.Stub = Base.extend({
+        constructor: function () {
+          self.args = arguments;
+          Base.apply(this, arguments);
+        },
+        exec: function () {}
+      });
       this.runMethod = sinon.spy(Base.prototype, 'run');
-      util.inherits(this.stub, Base);
-      this.env.registerStub(this.stub, 'stub:run');
+      this.env.registerStub(this.Stub, 'stub:run');
     });
 
     afterEach(function () {
@@ -314,10 +316,12 @@ describe('Environment', function () {
       assert.equal(this.completeDummy, this.env.get('dummy:complete'));
     });
 
-    it('extend simple function with Base', function () {
+    it('extend simple function with Base', function (done) {
       assert.implement(this.env.get('dummy:simple'), Base);
-      this.env.run('dummy:simple');
-      assert.ok(this.simpleDummy.calledOnce);
+      this.env.run('dummy:simple', function () {
+        assert.ok(this.simpleDummy.calledOnce);
+        done();
+      }.bind(this));
     });
 
     it('throws if invalid generator', function () {


### PR DESCRIPTION
This is a basic refactoring offering the same functionnality as before but
with a queue system to manage the asynchronicity.

I PR right now as usual to get feedback. I'll add the priority queue a little later on.

Also need to add shimming for generators working with old Yo.

Related to #433
