### PR TITLE
Adding composer install option flag

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -37,8 +37,12 @@ install.runInstall = function (installer, paths, options, cb) {
     .on('exit', this.emit.bind(this, installer + 'Install:end', paths))
     .on('exit', function (err) {
       if (err === 127) {
-        this.log.error('Could not find ' + installer + '. Please install with ' +
+        if (installer === 'composer'){
+          this.log.error('Could not find composer. Please install it globally from http://getcomposer.org/ ');
+        } else {
+          this.log.error('Could not find ' + installer + '. Please install with ' +
                             '`npm install -g ' + installer + '`.');
+        }
       }
       cb(err);
     }.bind(this));
@@ -47,13 +51,14 @@ install.runInstall = function (installer, paths, options, cb) {
 };
 
 /**
- * Runs `npm` and `bower` in the generated directory concurrently and prints a
+ * Runs `npm` and `bower` or `composer` in the generated directory concurrently and prints a
  * message to let the user know.
  *
  * ### Options:
  *
  *   - `npm` Boolean whether to run `npm install` (`true`)
  *   - `bower` Boolean whether to run `bower install` (`true`)
+ *   - `composer` Boolean whether to run `composer install` (`false`)
  *   - `skipInstall` Boolean whether to skip automatic installation (`false`)
  *   - `skipMessage` Boolean whether to show the used bower/npm commands (`false`)
  *
@@ -62,6 +67,7 @@ install.runInstall = function (installer, paths, options, cb) {
  *     this.installDependencies({
  *       bower: true,
  *       npm: true,
+ *       composer: false,  
  *       skipInstall: false,
  *       callback: function () {
  *         console.log('Everything is ready!');
@@ -91,6 +97,7 @@ install.installDependencies = function (options) {
   options = _.defaults(options || {}, {
     bower: true,
     npm: true,
+    composer: false,
     skipInstall: false,
     skipMessage: false,
     callback: function () {}
@@ -110,6 +117,13 @@ install.installDependencies = function (options) {
     }.bind(this));
   }
 
+  if (options.composer) {
+    msg.commands.push('composer install');
+    commands.push(function (cb) {
+      this.composerInstall(null, null, cb);
+    }.bind(this));
+  }
+  
   if (msg.commands.length === 0) {
     throw new Error('installDependencies needs at least one of npm or bower to run.');
   }
@@ -145,4 +159,16 @@ install.bowerInstall = function install(paths, options, cb) {
 
 install.npmInstall = function install(paths, options, cb) {
   return this.runInstall('npm', paths, options, cb);
+};
+
+/**
+ * Receives a list of `paths`, and an Hash of `options` to install through composer.
+ *
+ * @param {String|Array} paths Packages to install
+ * @param {Object} options Options to invoke `composer install` with, see `composer help install`
+ * @param {Function} cb
+ */
+
+install.composerInstall = function install(paths, options, cb) {
+  return this.runInstall('composer', paths, options, cb);
 };

--- a/test/actions.js
+++ b/test/actions.js
@@ -416,6 +416,11 @@ describe('yeoman.generators.Base', function () {
         assert.deepEqual(this.commandsRun, ['bower', 'npm']);
       });
 
+      it('should spawn composer', function () {
+        this.dummy.installDependencies({ composer: true });
+        assert.deepEqual(this.commandsRun, ['bower', 'npm', 'composer']);
+      });
+      
       it('should not spawn anything with skipInstall', function () {
         this.dummy.installDependencies({ skipInstall: true });
         assert.deepEqual(this.commandsRun.length, 0);


### PR DESCRIPTION
Make it simpler for php developers to include 'composer.json' in
generators by adding a composer flag (default: false , backward
compatible) in options for installDependencies .
