### PR TITLE
Test coverage of the invoke method.

### DIFF
--- a/lib/actions/invoke.js
+++ b/lib/actions/invoke.js
@@ -21,24 +21,6 @@ module.exports = function invoke(namespace, options, cb) {
 
   var generator = this.env.create(namespace, options);
 
-  if (!generator.sourceRoot()) {
-    generator.sourceRoot(path.join(path.dirname(generator.resolved), 'templates'));
-  }
-
-  // validate the generator (show help on missing arguments/options)
-  // also show help if --help was specifically passed
-  var requiredArgs = generator._arguments.some(function (arg) {
-    return arg.config && arg.config.required;
-  });
-
-  if (!options.args.length && requiredArgs) {
-    return console.log(generator.help());
-  }
-
-  if (options.help) {
-    return console.log(generator.help());
-  }
-
   this.log.emit('up');
   this.log.invoke(namespace);
   this.log.emit('up');

--- a/test/invoke.js
+++ b/test/invoke.js
@@ -1,0 +1,40 @@
+/*global describe, it, before, after, beforeEach, afterEach */
+'use strict';
+
+var yo = require('..');
+var helpers = yo.test;
+var assert = yo.assert;
+
+describe('Base#invoke()', function () {
+  beforeEach(function () {
+    this.env = yo();
+    this.gen = new (helpers.createDummyGenerator())({
+      namespace: 'foo:lab',
+      resolved: 'path/',
+      env: this.env,
+      'skip-install': true
+    });
+    this.env.registerStub(yo.generators.Base.extend({
+      exec: function () { this.stubGenRunned = true; }
+    }), 'foo:bar');
+  });
+
+  it('invoke available generators', function (done) {
+    var invoked = this.gen.invoke('foo:bar', {
+      options: { 'skip-install': true }
+    });
+    invoked.on('end', function () {
+      assert(invoked.stubGenRunned);
+      done();
+    });
+  });
+
+  it('accept a callback argument', function (done) {
+    var invoked = this.gen.invoke('foo:bar', {
+      options: { 'skip-install': true }
+    }, function () {
+      assert(invoked.stubGenRunned);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Refactor some buggy behavior too:

Disabled the help logging. First of all this method will probably never be called because options are inside `options.options`, so it didn't check at the right place. And overalls, it is better the system throw an error rather than print the generator help IMO. Cleaner and it'll stop the process. - Also, we don't want to console log as this would break GUI interface.

`sourceRoot()` is never undefined or empty, so that line would never been called.
