### PR TITLE
Fix #414

### DIFF
--- a/lib/actions/fetch.js
+++ b/lib/actions/fetch.js
@@ -62,7 +62,7 @@ fetch.extract = function _extract(archive, destination, cb) {
     })
     .on('error', cb)
     .once('close', function () {
-      log.ok('\nDone in ' + destination).write();
+      log.write().ok('Done in ' + destination).write();
       cb();
     });
 };


### PR DESCRIPTION
Go back to previous behavior, in order to have:

```
     info This might take a few moments
....
✔ Done in /home/jerome/.cache/yeoman/symfony/symfony-standard/v2.4.1
```
