### PR TITLE
Add useDefaults option to mockPrompt

### DIFF
--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -181,6 +181,11 @@ exports.testDirectory = function (dir, cb) {
 exports.mockPrompt = function (generator, answers) {
   var origPrompt = generator.prompt;
   generator.prompt = function (prompts, done) {
+    prompts.forEach(function (prompt) {
+      if (!(prompt.name in answers)) {
+        answers[prompt.name] = prompt.default;
+      }
+    });
     done(answers);
   };
   generator.origPrompt = origPrompt;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -117,6 +117,20 @@ describe('yeoman.test', function () {
         done();
       });
     });
+
+    it('uses default values', function (done) {
+      this.generator.prompt([{ name: 'respuesta', type: 'input', default: 'bar' }], function (answers) {
+        assert.equal(answers.respuesta, 'bar');
+        done();
+      });
+    });
+
+    it('prefers mocked values', function (done) {
+      this.generator.prompt([{ name: 'answser', type: 'input', default: 'bar' }], function (answers) {
+        assert.equal(answers.answer, 'foo');
+        done();
+      });
+    });
   });
 
   describe('.before()', function () {


### PR DESCRIPTION
I wanted to test the default option flow in [my generator](https://github.com/goodeggs/generator-goodeggs-npm/blob/master/test/test-creation.coffee#L33).  `mockPrompt` didn't make this easy.  The `useDefaults` option makes this easy without breaking backwards compatibilty.

``` js
helpers.mockPrompt(generator, { answer: 'foo' }, { useDefaults: true });
```

See tests for expected results.
