### PR TITLE
Fix queue creation on enforceUpdate

### DIFF
--- a/lib/env/index.js
+++ b/lib/env/index.js
@@ -393,7 +393,8 @@ Environment.enforceUpdate = function (env) {
     env.adapter = new TerminalAdapter();
   }
   if (!env.runLoop) {
-    env.runLoop = new GroupedQueue();
+    env.runLoop = new GroupedQueue(['initialize', 'prompt', 'configure', 'default',
+    'write', 'conflicts', 'install', 'end']);
   }
   return env;
 };


### PR DESCRIPTION
Hello,

with 0.16.0 version of yeoman-generator I have always this error

```
generator-footguard/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:45
  this.__queues__[name].push( task, opt );
                        ^
TypeError: Cannot call method 'push' of undefined
    at Queue.add (/Volumes/Raid HD/Work/Perso/yeoman/test-footguard/node_modules/generator-footguard/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:45:25)
    at Generator.run (/Volumes/Raid HD/Work/Perso/yeoman/test-footguard/node_modules/generator-footguard/node_modules/yeoman-generator/lib/base.js:370:20)
    at Environment.run (/usr/local/share/npm/lib/node_modules/yo/node_modules/yeoman-generator/lib/env/index.js:315:20)
    at init (/usr/local/share/npm/lib/node_modules/yo/cli.js:95:7)
    at pre (/usr/local/share/npm/lib/node_modules/yo/cli.js:113:3)
    at Object.<anonymous> (/usr/local/share/npm/lib/node_modules/yo/cli.js:139:1)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
```

I fix it with pass sub-queue in enforeUpdate method of env.

I have an other problem with `installDependencies`, it always called when you run a generator and sub-generator. I remove the call in base generator run method.

Bye
Mathieu
