### PR TITLE
Jshint: don't process fixtures files

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+test/fixtures/**

--- a/.jshintrc
+++ b/.jshintrc
@@ -14,5 +14,6 @@
   "trailing": true,
   "smarttabs": true,
   "indent": 2,
-  "quotmark": "single"
+  "quotmark": "single",
+  "scripturl": true
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,8 @@ gulp.task('test', function (cb) {
 
 gulp.task('static', function () {
   return gulp.src([
-    'test/*.js',
+    'test/**/*.js',
+    '!test/fixtures/**/*.js',
     'lib/**/*.js',
     'benchmark/**/*.js',
     'main.js',

--- a/test/generators/test-angular.js
+++ b/test/generators/test-angular.js
@@ -1,8 +1,8 @@
-/*global describe before it */
+/*global describe, before, after, it, afterEach, beforeEach */
+'use strict';
 var path = require('path');
 var helpers = require('../..').test;
 var generators = require('../..');
-
 
 describe('Angular generator test', function () {
   // cleanup the temp dir and cd into it

--- a/test/generators/test-backbone.js
+++ b/test/generators/test-backbone.js
@@ -1,15 +1,16 @@
-
+/*global describe, before, after, it, afterEach, beforeEach */
+'use strict';
 var path    = require('path');
 var helpers = require('../..').test;
 
-describe('Backbone generator test', function() {
+describe('Backbone generator test', function () {
   before(helpers.before(path.join(__dirname, './temp')));
 
-  it('runs sucessfully', function(done) {
+  it('runs sucessfully', function (done) {
     helpers.runGenerator('backbone', done);
   });
 
-  it('creates expected files', function() {
+  it('creates expected files', function () {
    
     helpers.assertFile('app/scripts/models');
   
@@ -75,11 +76,11 @@ describe('Backbone generator test', function() {
   
   });
 
-  it('runs sucessfully with --coffee as argument', function(done) {
-    helpers.runGenerator('backbone', {coffee: true} ,done);
+  it('runs sucessfully with --coffee as argument', function (done) {
+    helpers.runGenerator('backbone', { coffee: true }, done);
   });
 
-  it('creates expected files when run with --coffee as argument', function(){
+  it('creates expected files when run with --coffee as argument', function () {
     helpers.assertFile('app/scripts/main.coffee');
 
     helpers.assertFile('app/scripts/routes/application-router.coffee');
@@ -91,11 +92,11 @@ describe('Backbone generator test', function() {
     helpers.assertFile('app/scripts/collections/application-collection.coffee');
   });
 
-  it('runs successfully with --test-framework as argument', function(done) {
-    helpers.runGenerator('backbone', {'test-framework': 'jasmine'} ,done);
+  it('runs successfully with --test-framework as argument', function (done) {
+    helpers.runGenerator('backbone', { 'test-framework': 'jasmine' }, done);
   });
 
-  it('creates jasmine files when run with --test-framework',function(){
+  it('creates jasmine files when run with --test-framework', function () {
     helpers.assertFile('test/runner/headless.js');
 
     helpers.assertFile('test/runner/html.js');

--- a/test/generators/test-bbb.js
+++ b/test/generators/test-bbb.js
@@ -1,15 +1,16 @@
-
+/*global describe, before, after, it, afterEach, beforeEach */
+'use strict';
 var path    = require('path');
 var helpers = require('../..').test;
 
-describe('Bbb generator test', function() {
+describe('Bbb generator test', function () {
   before(helpers.before(path.join(__dirname, './temp')));
 
-  it('runs sucessfully', function(done) {
+  it('runs sucessfully', function (done) {
     helpers.runGenerator('bbb', done);
   });
 
-  it('creates expected files', function() {
+  it('creates expected files', function () {
    
     helpers.assertFile('.editorconfig');
   

--- a/test/generators/test-ember-starter.js
+++ b/test/generators/test-ember-starter.js
@@ -1,15 +1,16 @@
-
+/*global describe, before, after, it, afterEach, beforeEach */
+'use strict';
 var path    = require('path');
 var helpers = require('../..').test;
 
-describe('Ember-Starter generator test', function() {
+describe('Ember-Starter generator test', function () {
   before(helpers.before(path.join(__dirname, './temp')));
 
-  it('runs sucessfully', function(done) {
+  it('runs sucessfully', function (done) {
     helpers.runGenerator('ember-starter', done);
   });
 
-  it('creates expected files', function() {
+  it('creates expected files', function () {
    
     helpers.assertFile('app/scripts');
   

--- a/test/generators/test-ember.js
+++ b/test/generators/test-ember.js
@@ -1,15 +1,16 @@
-
+/*global describe, before, after, it, afterEach, beforeEach */
+'use strict';
 var path    = require('path');
 var helpers = require('../..').test;
 
-describe('Ember generator test', function() {
+describe('Ember generator test', function () {
   before(helpers.before(path.join(__dirname, './temp')));
 
-  it('runs sucessfully', function(done) {
+  it('runs sucessfully', function (done) {
     helpers.runGenerator('ember', done);
   });
 
-  it('creates expected files', function() {
+  it('creates expected files', function () {
    
     helpers.assertFile('app/scripts/models');
   

--- a/test/generators/test-mocha-generator.js
+++ b/test/generators/test-mocha-generator.js
@@ -1,15 +1,16 @@
-
+/*global describe, before, after, it, afterEach, beforeEach */
+'use strict';
 var path    = require('path');
 var helpers = require('../..').test;
 
-describe('Mocha:Generator generator test', function() {
+describe('Mocha:Generator generator test', function () {
   before(helpers.before(path.join(__dirname, './temp')));
 
-  it('runs sucessfully', function(done) {
+  it('runs sucessfully', function (done) {
     helpers.runGenerator('mocha:generator', done);
   });
 
-  it('creates expected files', function() {
+  it('creates expected files', function () {
   
     // Use helpers.assertFile() to help you test the output of your generator
     //

--- a/test/generators/test-quickstart.js
+++ b/test/generators/test-quickstart.js
@@ -1,15 +1,16 @@
-
+/*global describe, before, after, it, afterEach, beforeEach */
+'use strict';
 var path    = require('path');
 var helpers = require('../..').test;
 
-describe('Quickstart generator test', function() {
+describe('Quickstart generator test', function () {
   before(helpers.before(path.join(__dirname, './temp')));
 
-  it('runs sucessfully', function(done) {
+  it('runs sucessfully', function (done) {
     helpers.runGenerator('quickstart', done);
   });
 
-  it('creates expected files', function() {
+  it('creates expected files', function () {
    
     helpers.assertFile('.editorconfig');
   

--- a/test/generators/test-testacular-app.js
+++ b/test/generators/test-testacular-app.js
@@ -1,15 +1,16 @@
-
+/*global describe, before, after, it, afterEach, beforeEach */
+'use strict';
 var path    = require('path');
 var helpers = require('../..').test;
 
-describe('Testacular:App generator test', function() {
+describe('Testacular:App generator test', function () {
   before(helpers.before(path.join(__dirname, './temp')));
 
-  it('runs sucessfully', function(done) {
+  it('runs sucessfully', function (done) {
     helpers.runGenerator('testacular:app', done);
   });
 
-  it('creates expected files', function() {
+  it('creates expected files', function () {
    
     helpers.assertFile('testacular.conf.js');
   


### PR DESCRIPTION
Hi,

I added the `.jshintignore` and modified thie `gulpfile.js` for ignore fixtures and include all others files in test folders. I fix some jshint issues on test generator.

I hope this was what you wanted.

ref to #501
