### PR TITLE
Correct comments for `Base.prototype.option`

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -178,8 +178,7 @@ Base.prototype.spawnCommand = require('./actions/spawn_command');
  *
  *   - `desc` Description for the option
  *   - `type` Either Boolean, String or Number
- *   - `default` Default value
- *   - `banner` String to show on usage notes
+ *   - `defaults` Default value
  *   - `hide` Boolean whether to hide from help
  *
  * @param {String} name


### PR DESCRIPTION
- Change `default` to `defaults`
- Remove `banner` as it's never used for `option`.
## 

![](https://cloud.githubusercontent.com/assets/1223565/2530702/74198498-b529-11e3-9f58-6115ad64ba45.png)
