### PR TITLE
add npm arguments option

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -54,6 +54,7 @@ install.runInstall = function (installer, paths, options, cb) {
  * ### Options:
  *
  *   - `npm` Boolean whether to run `npm install` (`true`)
+ *   - `npmArgs` String pass arguments to `npm install` (`''`)
  *   - `bower` Boolean whether to run `bower install` (`true`)
  *   - `skipInstall` Boolean whether to skip automatic installation (`false`)
  *   - `skipMessage` Boolean whether to show the used bower/npm commands (`false`)
@@ -92,6 +93,7 @@ install.installDependencies = function (options) {
   options = _.defaults(options || {}, {
     bower: true,
     npm: true,
+    npmArgs: '',
     skipInstall: false,
     skipMessage: false,
     callback: function () {}
@@ -110,7 +112,7 @@ install.installDependencies = function (options) {
   }
 
   if (options.npm) {
-    msg.commands.push('npm install');
+    msg.commands.push('npm install ' + options.npmArgs);
     commands.push(function (cb) {
       this.env.runLoop.add('end', function (done) {
         this.npmInstall(null, null, function () {


### PR DESCRIPTION
Give an options to `npm install`

In my case, I use a npm proxy registry since npm is too slow. So I can

```
this.installDependencies({
  npm: true,
  npmArgs: '--registry=http://r.cnpmjs.org'
})
```
