### PR TITLE
Improved error handling for missing git config

### DIFF
--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -28,7 +28,12 @@ user.git = {
 
     if (shell.which('git')) {
       name = shell.exec('git config --get user.name', { silent: true }).output.trim();
-      nameCache[process.cwd()] = name;
+      if (name === '') {
+        name = undefined;
+      }
+      else {
+        nameCache[process.cwd()] = name;
+      }
     }
 
     return name;
@@ -43,7 +48,12 @@ user.git = {
 
     if (shell.which('git')) {
       email = shell.exec('git config --get user.email', { silent: true }).output.trim();
-      emailCache[process.cwd()] = email;
+      if (email === '') {
+        email = undefined;
+      }
+      else {
+        emailCache[process.cwd()] = email;
+      }
     }
 
     return email;


### PR DESCRIPTION
This will set name / email to undefined if .gitconfig does not exist.

Currently if the values are not set shell.exec will return an empty string and the line `this.user.git.username || process.env.user || process.env.username,` from generator-generator's app generator will always return empty string.

If this pull is accepted generator-generator will need to be updated to handle this.user.git.email returning `undefined` or you might want to only include the error handling for name
