### PR TITLE
Small updates to "help"

### DIFF
--- a/lib/actions/help.js
+++ b/lib/actions/help.js
@@ -9,27 +9,6 @@ var fs = require('fs');
 var help = module.exports;
 
 /**
- * Generate the default banner for help output, adjusting output to
- * argument type.
- *
- * Options:
- *
- *   - `name` Uppercased value to display (only relevant with `String` type)
- *   - `type` String, Number, Object or Array
- *
- * @param {Object} config
- */
-
-help.bannerFor = function bannerFor(config) {
-  return config.type === Boolean ? '' :
-    config.type === String ? config.name.toUpperCase() :
-    config.type === Number ? 'N' :
-    config.type === Object ? 'key:value' :
-    config.type === Array ? 'one two three' :
-    '';
-};
-
-/**
  * Tries to get the description from a USAGE file one folder above the
  * source root otherwise uses a default description.
  */
@@ -116,13 +95,19 @@ help.desc = function desc(description) {
   return this;
 };
 
+/**
+ * Get help text for arguments
+ * @returns {String} Text of options in formatted table
+ */
 help.argumentsHelp = function argumentsHelp() {
-  var rows = this._arguments.map(function (a) {
+  var rows = this._arguments.map(function (arg) {
+    var config = arg.config;
     return [
       '',
-      a.name ? a.name : '',
-      a.config.type ? '# Type: ' + a.config.type.name : '',
-      'Required: ' + a.config.required
+      arg.name ? arg.name : '',
+      config.desc ? '# ' + config.desc : '',
+      config.type ? 'Type: ' + config.type.name : '',
+      'Required: ' + config.required
     ];
   });
 
@@ -132,9 +117,9 @@ help.argumentsHelp = function argumentsHelp() {
 };
 
 /**
- * Returns the list of options in formatted table.
+ * Get help text for options
+ * @returns {String} Text of options in formatted table
  */
-
 help.optionsHelp = function optionsHelp() {
   var options = this._options.filter(function (el) {
     return !el.hide;
@@ -149,13 +134,14 @@ help.optionsHelp = function optionsHelp() {
     return opts && opts.name !== 'help';
   });
 
-  var rows = options.concat(hookOpts).map(function (o) {
+  var rows = options.concat(hookOpts).map(function (opt) {
+    var defaults = opt.defaults;
     return [
       '',
-      o.alias ? '-' + o.alias + ', ' : '',
-      '--' + o.name,
-      o.desc ? '# ' + o.desc : '',
-      o.defaults == null ? '' : 'Default: ' + o.defaults
+      opt.alias ? '-' + opt.alias + ', ' : '',
+      '--' + opt.name,
+      opt.desc ? '# ' + opt.desc : '',
+      defaults === null || defaults === '' ? '' : 'Default: ' + opt.defaults
     ];
   });
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -46,7 +46,6 @@ var fileLogger = { write: noop, warn: noop };
  * @property {Object}  env         - the current Environment being run
  * @property {Object}  args        - Provide arguments at initialization
  * @property {String}  resolved    - the path to the current generator
- * @property {String}  generatorName
  * @property {String}  description - Used in `--help` output
  * @property {String}  appname     - The application name
  * @property {Storage} config      - `.yo-rc` config file manager
@@ -80,7 +79,6 @@ var Base = module.exports = function Base(args, options) {
 
   this.env = this.options.env;
   this.resolved = this.options.resolved;
-  this.generatorName = this.options.name || '';
 
   require('./env').enforceUpdate(this.env);
 
@@ -118,7 +116,6 @@ var Base = module.exports = function Base(args, options) {
   this._options = [];
   this._hooks = [];
   this._composedWith = [];
-  this._conflicts = [];
   this.appname = this.determineAppname();
 
   this.option('help', {
@@ -225,8 +222,6 @@ Base.prototype.option = function option(name, config) {
 
   if (!opt) {
     this._options.push(config);
-  } else {
-    opt = config;
   }
 
   if (!this.options[name]) {
@@ -253,7 +248,6 @@ Base.prototype.option = function option(name, config) {
  *   - `optional` Boolean whether it is optional
  *   - `type` String, Number, Array, or Object
  *   - `defaults` Default value for this argument
- *   - `banner` String to show on usage notes
  *
  * @param {String} name
  * @param {Object} config
@@ -263,11 +257,9 @@ Base.prototype.argument = function argument(name, config) {
   config = config || {};
   _.defaults(config, {
     name: name,
-    required: config.defaults == null ? true : false,
+    required: config.defaults == null,
     type: String
   });
-
-  config.banner = config.banner || this.bannerFor(config);
 
   this._arguments.push({
     name: name,
@@ -314,7 +306,7 @@ Base.prototype.argument = function argument(name, config) {
  * none is given, the same values used to initialize the invoker are
  * used to initialize the invoked.
  *
- * @param {String|Array} [args]
+ * @param {String|Array|Function} [args]
  * @param {Function} [cb]
  */
 
@@ -407,7 +399,7 @@ Base.prototype.run = function run(args, cb) {
 /**
  * Goes through all registered hooks, invoking them in series.
  *
- * @param {Function} cb
+ * @param {Function} [cb]
  */
 
 Base.prototype.runHooks = function runHooks(cb) {

--- a/test/base.js
+++ b/test/base.js
@@ -499,19 +499,35 @@ describe('yeoman.generators.Base', function () {
       this.dummy.option('ooOoo');
       this.dummy.argument('baz', {
         type: Number,
-        required: false
+        required: false,
+        desc: 'definition; explanation; summary'
       });
       this.dummy.desc('A new desc for this generator');
       var help = this.dummy.help();
+      var expected = [
+        'Usage:',
+        'yo dummy [options] [<baz>]',
+        '',
+        'A new desc for this generator',
+        '',
+        'Options:',
+        '-h, --help # Print generator\'s options and usage Default: false',
+        '--hook1 # Hook1 to be invoked',
+        '--hook2 # Hook2 to be invoked',
+        '--hook3 # Hook3 to be invoked',
+        '--hook4 # Hook4 to be invoked',
+        '--ooOoo # Description for ooOoo Default: false',
+        '',
+        'Arguments:',
+        'baz # definition; explanation; summary Type: Number Required: false',
+        ''
+      ];
 
-      assert.ok(help.match('Usage:'));
-      assert.ok(help.match('yo dummy \\[options\\] \\[<baz>\\]'));
-      assert.ok(help.match('A new desc for this generator'));
-      assert.ok(help.match('Options:'));
-      assert.ok(help.match('--help   # Print generator\'s options and usage'));
-      assert.ok(help.match('--ooOoo  # Description for ooOoo'));
-      assert.ok(help.match('Arguments:'));
-      assert.ok(help.match('baz  # Type: Number  Required: false'));
+      help.split('\n').forEach(function(line, i) {
+        // do not test whitespace; we care about the content, not formatting.
+        // formatting is best left up to the tests for module "text-table"
+        assert.textEqual(line.trim().replace(/\s+/g, ' '), expected[i]);
+      });
     });
   });
 


### PR DESCRIPTION
Help-related:
- FEATURE: can use `desc` field with arguments
- removed unused `help.bannerFor()`
- updated some JSDoc
- option defaults no longer display if default value is an empty string
- rewrote unit tests for `help.help()` function
  - the old tests made it difficult to debug since Mocha would only report truthiness
  - using the updated method, we now compare strings and can easily see any differences as reported by the assertions
  - I also elected to ignore extra whitespace here, because I want to test the content; not the `text-table` module's output.

General:
- removed unused vars in `base.js`
- updated JSDoc tags in `base.js`
- simplified a boolean expression
