### PR TITLE
Copy for the non UTF-8 text file

### DIFF
--- a/lib/actions/actions.js
+++ b/lib/actions/actions.js
@@ -34,7 +34,7 @@ actions.cacheRoot = function cacheRoot() {
 };
 
 // Copy helper for two versions of copy action
-actions._prepCopy = function _prepCopy(source, destination, process) {
+actions._prepCopy = function _prepCopy(source, destination, process, bulk) {
   var body;
   destination = destination || source;
 
@@ -47,7 +47,7 @@ actions._prepCopy = function _prepCopy(source, destination, process) {
   destination = this.isPathAbsolute(destination) ? destination : path.join(this.destinationRoot(), destination);
 
   var encoding = null;
-  var binary = isBinaryFile(source);
+  var binary = bulk || isBinaryFile(source);
   if (!binary) {
     encoding = 'utf8';
   }
@@ -136,7 +136,7 @@ actions.copy = function copy(source, destination, process) {
 
 actions.bulkCopy = function bulkCopy(source, destination, process) {
 
-  var file = this._prepCopy(source, destination, process);
+  var file = this._prepCopy(source, destination, process, true);
 
   mkdirp.sync(path.dirname(file.destination));
   fs.writeFileSync(file.destination, file.body);


### PR DESCRIPTION
I include `.bat` file to the generator for Windows.
All other files are UTF-8, but only this is SHIFT_JIS in the Japanese environment.

I thought that `bulkCopy` was suitable for this, but UTF-8 was used in `bulkCopy` too.
This fix always copies a binary in `bulkCopy`.
