### PR TITLE
Fix treatment of mockPrompt() default functions

### DIFF
--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -191,7 +191,7 @@ exports.mockPrompt = function (generator, answers) {
     prompts.forEach(function (prompt) {
       if (!(prompt.name in answers)) {
         if (_.isFunction(prompt.default)) {
-          answers[prompt.name] = prompt.default();
+          answers[prompt.name] = prompt.default(answers);
         } else {
           answers[prompt.name] = prompt.default;
         }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -149,6 +149,17 @@ describe('yeoman.test', function () {
       });
     });
 
+    it('passes answers object to default value functions', function (done) {
+      var defaultFn = function (answers) {
+        assert.ok(answers, 'Did not pass answers object to mocked default function');
+        return answers.answer + 'bar';
+      };
+      this.generator.prompt([{ name: 'fromDefaultFn', type: 'input', default: defaultFn }], function (answers) {
+        assert.equal(answers.fromDefaultFn, 'foobar');
+        done();
+      });
+    });
+
     it('uses default values when no answers is passed', function (done) {
       var generator = env.instantiate(helpers.createDummyGenerator());
       helpers.mockPrompt(generator);


### PR DESCRIPTION
When assigning prompt defaults as functions, the `mockPrompt` helper was setting the mocked answer as `"function () { [native code] }"`. This is somewhat less than useful. It also accounts for the `answers` parameter sent to prompt default functions.

Additionally, I fixed some typos that were potentially obfuscating the accuracy of some tests. "Answer" is a weird word.
