### PR TITLE
when property is defined by calling `argument()`, set values to `this.args`

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -276,7 +276,7 @@ Base.prototype.argument = function argument(name, config) {
       return position >= this.args.length ? config.defaults : value;
     },
     set: function (value) {
-      this[name] = value;
+      this.args[position] = value;
     }
   });
 

--- a/test/base.js
+++ b/test/base.js
@@ -324,6 +324,12 @@ describe('yeoman.generators.Base', function () {
       assert.equal(this.dummy.foo, 'bar');
     });
 
+    it('can still be set as a property once defined', function () {
+      this.dummy.argument('foo');
+      this.dummy.foo = 'barbar';
+      assert.equal(this.dummy.foo, 'barbar');
+    });
+
     it('slice positional arguments when config.type is Array', function () {
       this.dummy.argument('bar', { type: Array });
       assert.deepEqual(this.dummy.bar, ['bar', 'baz', 'bom']);


### PR DESCRIPTION
fixes #560
