### PR TITLE
passes in arguments and options when calling `env.create()`

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -88,7 +88,6 @@ var Base = module.exports = function Base(args, options) {
   // checks required paramaters
   assert(this.options.env, 'You must provide the environment object. Use env#create() to create a new generator.');
   assert(this.options.resolved, 'You must provide the resolved path value. Use env#create() to create a new generator.');
-
   this.env = this.options.env;
   this.resolved = this.options.resolved;
 

--- a/lib/test/run-context.js
+++ b/lib/test/run-context.js
@@ -65,14 +65,13 @@ RunContext.prototype._run = function () {
     this.env.registerStub(this.Generator, namespace);
   }
 
-  this.generator = this.env.create(namespace);
+  this.generator = this.env.create(namespace, {
+    arguments: this.args,
+    options: _.extend({
+      'skip-install': true
+    }, this.options)
+  });
   helpers.mockPrompt(this.generator, this._answers);
-
-  this.generator.args = this.args;
-  this.generator.arguments = this.args;
-  this.generator.options = _.extend({
-    'skip-install': true
-  }, this.options);
 
   this.generator.once('end', this.emit.bind(this, 'end'));
   this.emit('ready', this.generator);


### PR DESCRIPTION
fixes #566
