### PR TITLE
sorted grammatical error

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -350,7 +350,7 @@ Base.prototype.run = function run(args, cb) {
 
   var methods = Object.keys(Object.getPrototypeOf(this));
 
-  assert(methods.length, 'This Generator is empty. Add at least one method for it to be runned.');
+  assert(methods.length, 'This Generator is empty. Add at least one method for it to run.');
 
   this.env.runLoop.once('end', function () {
     self.emit('end');


### PR DESCRIPTION
Changed `This Generator is empty. Add at least one method for it to be runned.` to `This Generator is empty. Add at least one method for it to run.`; the wording was annoying me.
