### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "github-username": "~0.1.1",
     "glob": "^4.0.2",
     "grouped-queue": "^0.3.0",
-    "gruntfile-editor": "^0.1.0",
+    "gruntfile-editor": "^0.1.1",
     "iconv-lite": "^0.2.10",
     "inquirer": "^0.5.0",
     "isbinaryfile": "^2.0.0",


### PR DESCRIPTION
Gruntfile-editor 0.1.0 did not have the "loadNpmTask" method in its index.js, but 0.1.1 does have it now.
