### PR TITLE
Bugfix when try to define gruntfile property, and that has already been defined.

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -146,26 +146,28 @@ var Base = module.exports = function Base(args, options) {
   this.sourceRoot(path.join(path.dirname(this.resolved), 'templates'));
 
   // Only instantiate the Gruntfile API when requested
-  Object.defineProperty(this, 'gruntfile', {
-    get: function () {
-      var gruntfile;
-      if (!this.env.gruntfile) {
-        // Use actual Gruntfile.js or the default one
-        try {
-          gruntfile = this.dest.read('Gruntfile.js');
-        } catch (e) {}
-        this.env.gruntfile = new GruntfileEditor(gruntfile);
+  if (!this.hasOwnProperty('gruntfile')) {
+    Object.defineProperty(this, 'gruntfile', {
+      get: function () {
+        var gruntfile;
+        if (!this.env.gruntfile) {
+          // Use actual Gruntfile.js or the default one
+          try {
+            gruntfile = this.dest.read('Gruntfile.js');
+          } catch (e) {}
+          this.env.gruntfile = new GruntfileEditor(gruntfile);
+        }
+
+        // Schedule the creation/update of the Gruntfile
+        this.env.runLoop.add('writing', function (done) {
+          this.dest.write('Gruntfile.js', this.env.gruntfile.toString());
+          done();
+        }.bind(this), { once: 'gruntfile:write' });
+
+        return this.env.gruntfile;
       }
-
-      // Schedule the creation/update of the Gruntfile
-      this.env.runLoop.add('writing', function (done) {
-        this.dest.write('Gruntfile.js', this.env.gruntfile.toString());
-        done();
-      }.bind(this), { once: 'gruntfile:write' });
-
-      return this.env.gruntfile;
-    }
-  });
+    });
+  }
 };
 
 util.inherits(Base, events.EventEmitter);


### PR DESCRIPTION
➜  projects  yo jhipster:entity teste                              

/home/eduardo/.nvm/v0.10.28/lib/node_modules/generator-jhipster/node_modules/yeoman-generator/lib/base.js:150
  Object.defineProperty(this, 'gruntfile', {
         ^
TypeError: Cannot redefine property: gruntfile
    at Function.defineProperty (native)
    at EntityGenerator.Base (/home/eduardo/.nvm/v0.10.28/lib/node_modules/generator-jhipster/node_modules/yeoman-generator/lib/base.js:150:10)
    at EntityGenerator.module.exports.Base.extend.constructor (/home/eduardo/.nvm/v0.10.28/lib/node_modules/generator-jhipster/node_modules/yeoman-generator/lib/named-base.js:19:10)
    at EntityGenerator.Generator (/home/eduardo/.nvm/v0.10.28/lib/node_modules/generator-jhipster/script-base.js:10:33)
    at new EntityGenerator (/home/eduardo/.nvm/v0.10.28/lib/node_modules/generator-jhipster/entity/index.js:11:14)
    at Environment.instantiate (/home/eduardo/.nvm/v0.10.28/lib/node_modules/yo/node_modules/yeoman-generator/lib/env/index.js:269:10)
    at Environment.create (/home/eduardo/.nvm/v0.10.28/lib/node_modules/yo/node_modules/yeoman-generator/lib/env/index.js:246:15)
    at Environment.run (/home/eduardo/.nvm/v0.10.28/lib/node_modules/yo/node_modules/yeoman-generator/lib/env/index.js:305:24)
    at init (/home/eduardo/.nvm/v0.10.28/lib/node_modules/yo/cli.js:113:7)
    at pre (/home/eduardo/.nvm/v0.10.28/lib/node_modules/yo/cli.js:131:3)
