### PR TITLE
add missing cb function

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -421,7 +421,7 @@ Base.prototype.run = function run(args, cb) {
     }.bind(this));
   }.bind(this));
 
-  this.runHooks();
+  this.runHooks.bind(this, cb);
   _.invoke(this._composedWith, 'run');
 
   return this;


### PR DESCRIPTION
Fixes #589 but breaks a lot of tests. The cb function wasn't getting passed in to the runHooks function. Not actually sure what the correct fix is. 
