### PR TITLE
expand logging to not be limited to strings

### DIFF
--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -61,9 +61,6 @@ module.exports = function logger() {
   // Retunrns the logger
   function log(msg, ctx) {
     msg = msg || '';
-    if (ctx == null) {
-      ctx = {};
-    }
 
     if (typeof ctx === 'object' && !Array.isArray(ctx)) {
       console.error(formatter(msg, ctx));

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -74,6 +74,29 @@ describe('TerminalAdapter', function () {
       assert.equal(logMessage, 'Zero = 0, One = 1\n');
     });
 
+    it('boolean values', function () {
+      this.adapter.log(true);
+      assert(this.spyerror.withArgs(true).calledOnce);
+      assert.equal(logMessage, 'true\n');
+    });
+
+    it('#write() numbers', function () {
+      this.adapter.log(42);
+      assert(this.spyerror.withArgs(42).calledOnce);
+      assert.equal(logMessage, 42);
+    });
+
+    it('#write() objects', function () {
+      var outputObject = {
+        something: 72,
+        another: 12
+      };
+
+      this.adapter.log(outputObject);
+      assert(this.spyerror.withArgs(outputObject).calledOnce);
+      assert.equal(logMessage, '{ something: 72, another: 12 }\n');
+    });
+
   });
 
   describe('#log', function () {


### PR DESCRIPTION
Previously, doing something like `this.log(true)` threw an error. Now it will behave more like console.log.

Also, I don't think the ctx check was really needed and in fact probably hurt more than it helped.
