### PR TITLE
use a second dummy generator instead of gen-ang

### DIFF
--- a/test/env.resolver.js
+++ b/test/env.resolver.js
@@ -17,7 +17,7 @@ describe('Environment Resolver', function () {
       process.chdir(this.projectRoot);
       shell.exec('npm install', { silent: true });
       shell.exec('npm install generator-jquery', { silent: true });
-      shell.exec('npm install -g generator-angular generator-dummy', { silent: true });
+      shell.exec('npm install -g generator-dummytest generator-dummy', { silent: true });
 
       fs.symlinkSync(
         path.resolve('../custom-generator-extend'),
@@ -55,8 +55,8 @@ describe('Environment Resolver', function () {
     });
 
     globalLookupTest('register global generators', function () {
-      assert.ok(this.env.get('angular:app'));
-      assert.ok(this.env.get('angular:controller'));
+      assert.ok(this.env.get('dummytest:app'));
+      assert.ok(this.env.get('dummytest:controller'));
     });
 
     it('register symlinked generators', function () {


### PR DESCRIPTION
The second generator is almost a real generator. Only thing keeping it from being a real boy is it doing something. But its structured and written like a real generator.

Did this to speed up testing times (30s down to about 8s) but mostly because yeoman-generator testing kept clobbering my generator-angular development (by installing the published version instead of keeping my `npm linked` version alone).
