### PR TITLE
Don't validate skipped prompts

### DIFF
--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -197,6 +197,12 @@ exports.mockPrompt = function (generator, answers) {
         }
       }
 
+      if (_.isFunction(prompt.when) && !prompt.when(answers)) {
+        // Skip further processing (like `validate`) for prompts
+        // that should not be executed
+        return;
+      }
+
       if (_.isFunction(prompt.validate)) {
         var validation = prompt.validate(answers[prompt.name]);
         if (validation !== true) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -234,6 +234,20 @@ describe('yeoman.test', function () {
         done();
       }.bind(this));
     });
+
+    it('does not call validation function when prompt should be skipped', function (done) {
+      var validateFunc = sinon.stub().returns(true);
+      helpers.mockPrompt(this.generator);
+      this.generator.prompt({
+        name: 'answer',
+        type: 'input',
+        when: function () { return false; },
+        validate: validateFunc
+      }, function () {
+        sinon.assert.notCalled(validateFunc);
+        done();
+      });
+    });
   });
 
   describe('.before()', function () {


### PR DESCRIPTION
Fix mockPrompt so that `validate` is not called when `when` returns false. This makes the mocked behaviour consistent with Inquirer.js and prevents test failures caused by `validate` functions not expecting an undefined value.

Close #600
