### PR TITLE
Run 'when' and 'validate' with correct scope in helpers.mockPrompt

### DIFF
--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -197,14 +197,14 @@ exports.mockPrompt = function (generator, answers) {
         }
       }
 
-      if (_.isFunction(prompt.when) && !prompt.when(answers)) {
+      if (_.isFunction(prompt.when) && !prompt.when.call(generator, answers)) {
         // Skip further processing (like `validate`) for prompts
         // that should not be executed
         return;
       }
 
       if (_.isFunction(prompt.validate)) {
-        var validation = prompt.validate(answers[prompt.name]);
+        var validation = prompt.validate.call(generator, answers[prompt.name]);
         if (validation !== true) {
           if (generator.prompt.errors == null) {
             generator.prompt.errors = [];


### PR DESCRIPTION
This is needed in order to allow `generator-generator` to run with version 0.17.0 of `yeoman-generator`
