### PR TITLE
Allow custom strip values, rather than defaulting to 1.

### DIFF
--- a/lib/actions/fetch.js
+++ b/lib/actions/fetch.js
@@ -48,7 +48,7 @@ fetch.extract = function _extract(archive, destination, cb, strip) {
   var opts = {
     extract: true,
     proxy: proxy,
-    strip: _isNumber(strip) ? strip : 1
+    strip: _.isNumber(strip) ? strip : 1
   };
 
   var dl = download(archive, destination, opts);


### PR DESCRIPTION
Unable to extract tar with multiple folders as root when the strip value is set to 1, would like the ability to set strip value when calling "extract" to allow for more flexibility of file structure within tarballs.

Not sure my solution is the best approach but hopefully something can be done to change this.
