### PR TITLE
Add a create method for instantiating a generator in unit test

### DIFF
--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -325,3 +325,12 @@ exports.registerDependencies = function (env, dependencies) {
 exports.run = function (Generator) {
   return new RunContext(Generator);
 };
+
+/**
+ * Create an instance of the provided Generator
+ * @param  {String|Function} Generator - Generator constructor or namespace
+ * @return {RunContext}
+ */
+exports.create = function (Generator) {
+  return new RunContext(Generator, false);
+};

--- a/lib/test/run-context.js
+++ b/lib/test/run-context.js
@@ -14,18 +14,24 @@ var helpers = require('./helpers');
  * @param  {String|Function} Generator - Namespace or generator constructor. If the later
  *                                       is provided, then namespace is assumed to be
  *                                       'gen:test' in all cases
+ * @param {Boolean} [shouldRun=true] - A flag for running or just creating an instance of the generator.
  * @return {this}
  */
 
-var RunContext = module.exports = function RunContext(Generator) {
+var RunContext = module.exports = function RunContext(Generator, shouldRun) {
+  shouldRun = shouldRun !== false;
+
   this._asyncHolds = 0;
   this.runned = false;
   this.args = [];
   this.options = {};
   this._dependencies = [];
   this.Generator = Generator;
-
-  setTimeout(this._run.bind(this), 10);
+  if (shouldRun) {
+    setTimeout(this._run.bind(this), 10);
+  } else {
+    setTimeout(this._create.bind(this), 10);
+  }
 };
 
 util.inherits(RunContext, EventEmitter);
@@ -79,6 +85,40 @@ RunContext.prototype._run = function () {
 };
 
 /**
+ * Method called when the context is ready to create an instance of the generator
+ * @private
+ */
+
+RunContext.prototype._create = function () {
+  if (this._asyncHolds !== 0 || this.runned) return;
+  this.runned = true;
+
+  var namespace;
+  this.env = yeoman();
+
+  helpers.registerDependencies(this.env, this._dependencies);
+
+  if (_.isString(this.Generator)) {
+    namespace = this.env.namespace(this.Generator);
+    this.env.register(this.Generator);
+  } else {
+    namespace = 'gen:test';
+    this.env.registerStub(this.Generator, namespace);
+  }
+
+  this.generator = this.env.create(namespace, {
+    arguments: this.args,
+    options: _.extend({
+      'skip-install': true
+    }, this.options)
+  });
+  helpers.mockPrompt(this.generator, this._answers);
+
+  this.generator.once('end', this.emit.bind(this, 'end'));
+  this.emit('ready', this.generator);
+};
+
+/**
  * Clean the provided directory, then change directory into it
  * @param  {String} dirPath - Directory path (relative to CWD). Prefer passing an absolute
  *                            file path for predictable results
@@ -99,7 +139,7 @@ RunContext.prototype.inDir = function (dirPath, cb) {
  */
 
 RunContext.prototype.withArguments = function (args) {
-  var argsArray =  _.isString(args) ? args.split(' ') : args;
+  var argsArray = _.isString(args) ? args.split(' ') : args;
   assert(_.isArray(argsArray), 'args should be either a string separated by spaces or an array');
   this.args = this.args.concat(argsArray);
   return this;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -287,4 +287,12 @@ describe('yeoman.test', function () {
       assert(helpers.run(helpers.createDummyGenerator()) instanceof RunContext);
     });
   });
+
+  describe('.create()', function () {
+    it('return a RunContext object', function () {
+      var ctx = helpers.create(helpers.createDummyGenerator());
+      assert(ctx instanceof RunContext);
+      assert.equal(ctx.runned, false);
+    });
+  });
 });

--- a/test/run-context.js
+++ b/test/run-context.js
@@ -25,6 +25,35 @@ describe('RunContext', function () {
       });
     });
 
+    it('accept flgRun false parameter and create an instance of the generator without running it', function (done) {
+      this.runSpy = sinon.spy(RunContext.prototype._run);
+      this.createSpy = sinon.spy(RunContext.prototype._create);
+      RunContext.prototype._run = this.runSpy;
+      RunContext.prototype._create = this.createSpy;
+      var ctx = new RunContext(path.join(__dirname, './fixtures/custom-generator-simple'), false);
+
+      ctx.on('ready', function () {
+        assert(this.runSpy.notCalled);
+        sinon.assert.calledOnce(this.createSpy);
+        done();
+      }.bind(this));
+
+    });
+
+    it('accept flgRun true parameter and run the generator', function (done) {
+      this.runSpy = sinon.spy(RunContext.prototype._run);
+      this.createSpy = sinon.spy(RunContext.prototype._create);
+      RunContext.prototype._run = this.runSpy;
+      RunContext.prototype._create = this.createSpy;
+      var ctx = new RunContext(path.join(__dirname, './fixtures/custom-generator-simple'), true);
+      ctx.on('end', function () {
+        assert(this.createSpy.notCalled);
+        sinon.assert.calledOnce(this.runSpy);
+        done();
+      }.bind(this));
+
+    });
+
     it('accept generator constructor parameter (and assign gen:test as namespace)', function (done) {
       this.ctx.on('ready', function () {
         assert(this.ctx.env.get('gen:test'));
@@ -153,7 +182,7 @@ describe('RunContext', function () {
     it('is chainable', function (done) {
       this.ctx.withOptions({ foo: 'bar' }).withOptions({ john: 'doe' });
       this.ctx.on('end', function () {
-        var options =  this.execSpy.firstCall.thisValue.options;
+        var options = this.execSpy.firstCall.thisValue.options;
         assert.equal(options.foo, 'bar');
         assert.equal(options.john, 'doe');
         done();


### PR DESCRIPTION
In a unit test, you sometimes need to test some methods of a generator without actually running it.
The new method `helpers.create`, will do exactly this, and offers the same api than the existing `helpers.run` method.

One possible scenario is that you want to unit test a custom base generator.
With this PR you can do:

``` javascript
it('add() is working', function(done) {
        var runGen = helpers.create(path.join(__dirname, '../custom-generator'))
            .inDir(path.join(os.tmpdir(), './temp-test'));
        this.runGen.on('ready', function() {
            var retval = runGen.generator.add(12, 13);
            assert(retval === 25);
            done()
        }.bind(this));
    });
```
