### PR TITLE
Fixes reference to __super__ property on the generated docs

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -674,7 +674,7 @@ Base.prototype.determineAppname = function () {
 
 /**
  * Extend this Class to create a new one inherithing this one.
- * Also add a helper __super__ object pointing to the parent prototypes methods
+ * Also add a helper \_\_super__ object pointing to the parent prototypes methods
  * @param  {Object} protoProps  Prototype properties (available on the instances)
  * @param  {Object} staticProps Static properties (available on the contructor)
  * @return {Object}             New sub class


### PR DESCRIPTION
I was let down by the docs saying that a **super** property is available on the extending generator, when the actual property name is **__super__**.

Below is a screenshot from the offending **Base** page and [here is the link to it](http://yeoman.github.io/generator/Base.html).

![image demonstrating the problem](http://i.imgur.com/6mf1RZS.png)

Turns out it was **jsdoc** parsing the underscores of the __super__ property as markdown.

This PR fixes it :)
