### PR TITLE
helpers.decorate returns original fn result when stub is false

### DIFF
--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -74,7 +74,7 @@ exports.decorate = function decorate(context, method, replacement, options) {
     var rep = replacement.apply(context, arguments);
 
     if (!options.stub) {
-      naturalMethod.apply(context, arguments);
+      return naturalMethod.apply(context, arguments);
     }
 
     return rep;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -58,10 +58,10 @@ describe('yeoman.test', function () {
 
   describe('.decorate()', function () {
     beforeEach(function () {
-      this.spy = sinon.spy();
-      this.spyStub = sinon.spy();
-      this.execSpy = sinon.spy();
-      this.execStubSpy = sinon.spy();
+      this.spy = sinon.stub().returns(1);
+      this.spyStub = sinon.stub().returns(2);
+      this.execSpy = sinon.stub().returns(3);
+      this.execStubSpy = sinon.stub().returns(4);
       this.ctx = {
         exec: this.execSpy,
         execStub: this.execStubSpy
@@ -69,8 +69,8 @@ describe('yeoman.test', function () {
 
       helpers.decorate(this.ctx, 'exec', this.spy);
       helpers.decorate(this.ctx, 'execStub', this.spyStub, { stub: true });
-      this.ctx.exec('foo', 'bar');
-      this.ctx.execStub();
+      this.execResult = this.ctx.exec('foo', 'bar');
+      this.execStubResult = this.ctx.execStub();
     });
 
     it('wraps a method', function () {
@@ -83,6 +83,14 @@ describe('yeoman.test', function () {
 
     it('skip original methods if stub: true', function () {
       assert(this.execStubSpy.notCalled);
+    });
+    
+    it('returns original methods if stub: false', function () {
+      assert.equal(this.execResult, 3);
+    });
+    
+    it('returns stub methods if stub: true', function () {
+      assert.equal(this.execStubResult, 2);
     });
   });
 


### PR DESCRIPTION
When decorating a method, you want to return the original method result.
The replacement is executed before, but the outcome should not change.
