### PR TITLE
Fix Error handling for generator

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -392,10 +392,11 @@ Base.prototype.run = function run(args, cb) {
 
       self.emit(methodName);
       self.emit('method', methodName);
-      method.apply(self, args);
-
-      if (!running) {
-        done();
+      try {
+        method.apply(self, args);
+        if (!running) return done();
+      } catch (err) {
+        self.emit('error', err);
       }
     });
   }

--- a/lib/test/run-context.js
+++ b/lib/test/run-context.js
@@ -74,6 +74,7 @@ RunContext.prototype._run = function () {
   helpers.mockPrompt(this.generator, this._answers);
 
   this.generator.once('end', this.emit.bind(this, 'end'));
+  this.generator.on('error', this.emit.bind(this, 'error'));
   this.emit('ready', this.generator);
   this.generator.run();
 };

--- a/test/base.js
+++ b/test/base.js
@@ -254,6 +254,18 @@ describe('yeoman.generators.Base', function () {
       this.testGen.run();
     });
 
+    it('can emit error from sync methods', function (done) {
+      var error = new Error();
+      this.TestGenerator.prototype.throwing = function () {
+        throw error;
+      };
+      this.testGen.on('error', function (err) {
+        assert.equal(err, error);
+        done();
+      });
+      this.testGen.run();
+    });
+
     it('run methods in series', function (done) {
       var async1Running = false;
       var async1Runned = false;


### PR DESCRIPTION
A generator raising an exception will now correctly emit an `error` event.
This can be used in unit test as the error event is now binded between the generator and its run context. 
