### PR TITLE
Fix gitignore to ignore log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Logs
+logs
+*.log
+
 node_modules/
 temp/
 temp.dev/


### PR DESCRIPTION
When running locally test, it produces a npm debug log file that need to be removed manually before a `git add .`.
This file and any other log file should be ignore by git.
