### PR TITLE
Rely on Inquirer for mocking prompt rather than duplicating logic

### DIFF
--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -7,10 +7,8 @@
 var fs = require('fs');
 var path = require('path');
 var _ = require('lodash');
-var async = require('async');
 var rimraf = require('rimraf');
 var mkdirp = require('mkdirp');
-var runAsync = require('run-async');
 var yeoman = require('yeoman-environment');
 var assert = require('./assert');
 var generators = require('../..');
@@ -184,69 +182,29 @@ exports.testDirectory = function (dir, cb) {
  */
 
 exports.mockPrompt = function (generator, answers) {
-
-  var origPrompt = generator.origPrompt || generator.prompt;
+  var promptModule = generator.env.adapter.prompt;
   answers = answers || {};
-  generator.prompt = function (prompts, done) {
-    if (!_.isArray(prompts)) {
-      prompts = [prompts];
-    }
-    async.each(prompts, function (prompt, done) {
-      var processDefault = function (after) {
-        if (!(prompt.name in answers)) {
-          if (_.isFunction(prompt.default)) {
-            runAsync(prompt.default, function (val) {
-              answers[prompt.name] = val;
-              after();
-            }, answers);
-          } else {
-            answers[prompt.name] = prompt.default;
-            after();
-          }
-        } else {
-          after();
-        }
-      };
 
-      // Skip further processing (like `validate`) for prompts
-      // that should not be executed
-      var processWhen = function (after) {
-        if (_.isFunction(prompt.when)) {
-          runAsync(prompt.when, after, answers);
-        } else {
-          after(true);
-        }
-      };
-
-      var processValidate = function (after) {
-        if (_.isFunction(prompt.validate)) {
-          runAsync(prompt.validate, function (validation) {
-            if (validation !== true) {
-              if (generator.prompt.errors == null) {
-                generator.prompt.errors = [];
-              }
-              generator.prompt.errors.push({
-                name: prompt.name,
-                message: validation
-              });
-            }
-            after();
-          }, answers[prompt.name]);
-        } else {
-          after();
-        }
-      };
-
-      processDefault(
-        processWhen.bind(null, function (goOn) {
-          if (!goOn) return done();
-          processValidate(done.bind(null, null));
-        }));
-    }, function () {
-      setTimeout(done.bind(null, answers), 0);
-    });
+  var DummyPrompt = function (q) {
+    this.question = q;
   };
-  generator.origPrompt = origPrompt;
+  DummyPrompt.prototype.run = function (cb) {
+    setTimeout(function () {
+      cb(answers[this.question.name] || this.question.default);
+    }.bind(this), 0);
+  };
+
+  Object.keys(promptModule.prompts).forEach(function (name) {
+    promptModule.registerPrompt(name, DummyPrompt);
+  });
+};
+
+/**
+ * Restore defaults prompts on a generator.
+ * @param {Generator} generator
+ */
+exports.restorePrompt = function (generator) {
+  generator.env.adapter.prompt.restoreDefaultPrompts();
 };
 
 /**

--- a/lib/test/run-context.js
+++ b/lib/test/run-context.js
@@ -22,7 +22,8 @@ var RunContext = module.exports = function RunContext(Generator) {
   this.runned = false;
   this.args = [];
   this.options = {};
-  this._dependencies = [];
+  this.answers = {};
+  this.dependencies = [];
   this.Generator = Generator;
 
   setTimeout(this._run.bind(this), 10);
@@ -55,7 +56,7 @@ RunContext.prototype._run = function () {
   var namespace;
   this.env = yeoman.createEnv();
 
-  helpers.registerDependencies(this.env, this._dependencies);
+  helpers.registerDependencies(this.env, this.dependencies);
 
   if (_.isString(this.Generator)) {
     namespace = this.env.namespace(this.Generator);
@@ -71,10 +72,16 @@ RunContext.prototype._run = function () {
       'skip-install': true
     }, this.options)
   });
-  helpers.mockPrompt(this.generator, this._answers);
 
-  this.generator.once('end', this.emit.bind(this, 'end'));
+  helpers.mockPrompt(this.generator, this.answers);
+
   this.generator.on('error', this.emit.bind(this, 'error'));
+  this.generator.once('end', function () {
+    helpers.restorePrompt(this.generator);
+    this.emit('end');
+    this.completed = true;
+  }.bind(this));
+
   this.emit('ready', this.generator);
   this.generator.run();
 };
@@ -124,7 +131,7 @@ RunContext.prototype.withOptions = function (options) {
  */
 
 RunContext.prototype.withPrompts = function (answers) {
-  this._answers = _.extend(this._answers || {}, answers);
+  this.answers = _.extend(this.answers, answers);
   return this;
 };
 
@@ -158,7 +165,7 @@ RunContext.prototype.withPrompt = RunContext.prototype.withPrompts;
 
 RunContext.prototype.withGenerators = function (dependencies) {
   assert(_.isArray(dependencies), 'dependencies should be an array');
-  this._dependencies = this._dependencies.concat(dependencies);
+  this.dependencies = this.dependencies.concat(dependencies);
   return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "glob": "^4.0.2",
     "gruntfile-editor": "^0.2.0",
     "iconv-lite": "^0.4.4",
-    "inquirer": "^0.7.1",
+    "inquirer": "^0.8.0",
     "isbinaryfile": "^2.0.0",
     "lodash": "^2.4.1",
     "mime": "^1.2.9",
@@ -55,7 +55,7 @@
     "shelljs": "^0.3.0",
     "underscore.string": "^2.3.1",
     "xdg-basedir": "^1.0.0",
-    "yeoman-environment": "^1.0.0"
+    "yeoman-environment": "^1.0.2"
   },
   "devDependencies": {
     "gulp": "^3.6.0",

--- a/test/conflicter.js
+++ b/test/conflicter.js
@@ -118,8 +118,9 @@ describe('Conflicter', function () {
     var me = fs.readFileSync(__filename, 'utf8');
 
     beforeEach(function () {
+      var prompt = inquirer.createPromptModule();
       var mockAdapter = {
-        prompt: inquirer.prompt,
+        prompt: prompt,
         diff: function () {},
         log: log
       };
@@ -131,12 +132,11 @@ describe('Conflicter', function () {
       Prompt.prototype.run = function (cb) {
         cb(this.answer);
       };
-      inquirer.registerPrompt('expand', Prompt);
+      prompt.registerPrompt('expand', Prompt);
       this.conflicter = new Conflicter(mockAdapter);
     });
 
     afterEach(function () {
-      inquirer.restoreDefaultPrompts();
       delete this.conflicter.force;
     });
 


### PR DESCRIPTION
As a side effect of relying on Inquirer, each Terminal Adapter now have
a self contained Inquirer context to prevent cross pollution between
multiple generators being runned at the same time.

This change also remove how we previously attached prompts validation
errors to the question object. This is not 100% backward compatible, but maintaining the full logic of Inquirer ourselve inside Yeoman is not a scalable solution for the future, so I'd say too bad (plus it is a pretty minor breaking change).

**Do not merge**: I linked my branch of Inquirer provider self-contained module in package.json. I might change some stuff before merging - or not. I'm leaving the branch out of couple day and I'll see how I feel about it after a while. Reviews welcomed over there: https://github.com/SBoudrias/Inquirer.js/pull/163

I'll have another go on this branch too, I see I missed some lines I should've cleaned up before sending this PR. Reviews welcomed anyway :)
