### PR TITLE
Add plumber to gulp test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ var jscs = require('gulp-jscs');
 var eslint = require('gulp-eslint');
 var istanbul = require('gulp-istanbul');
 var coveralls = require('gulp-coveralls');
+var plumber = require('gulp-plumber');
 
 var handleErr = function (err) {
   console.log(err.message);
@@ -36,9 +37,12 @@ gulp.task('test', function (cb) {
     'lib/**/*.js',
     'index.js'
   ])
-  .pipe(istanbul())
+  .pipe(istanbul({
+    includeUntested: true
+  }))
   .on('finish', function () {
     gulp.src(['test/*.js'])
+      .pipe(plumber())
       .pipe(mocha({
         reporter: 'spec',
         timeout: 100000

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "nock": "^0.45.0",
     "proxyquire": "^1.0.0",
     "sinon": "^1.9.1",
-    "gulp-eslint": "~0.1.8"
+    "gulp-eslint": "~0.1.8",
+    "gulp-plumber": "~0.6.6"
   }
 }


### PR DESCRIPTION
this is to always display the code coverage summary even when one or more tests are failing
