### PR TITLE
Created a TestAdapter and implemented on lib/test/run-context

### DIFF
--- a/lib/test/adapter.js
+++ b/lib/test/adapter.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var _ = require('lodash');
+var inquirer = require('inquirer');
+var sinon = require('sinon');
+var events = require('events');
+
+function DummyPrompt(answers, q) {
+  this.answers = answers;
+  this.question = q;
+}
+
+DummyPrompt.prototype.run = function (cb) {
+  setImmediate(function () {
+    cb(this.answers[this.question.name] || this.question.default);
+  }.bind(this));
+};
+
+function TestAdapter(answers) {
+
+  answers = answers || {};
+
+  this.prompt = inquirer.createPromptModule();
+
+  Object.keys(this.prompt.prompts).forEach(function (promptName) {
+    this.prompt.registerPrompt(promptName, DummyPrompt.bind(DummyPrompt, answers));
+  }, this);
+
+  this.diff = sinon.spy();
+
+  this.log = sinon.spy();
+
+  _.extend(this.log, events.EventEmitter.prototype);
+
+  // make sure all log methods are defined
+  [
+    'write',
+    'writeln',
+    'ok',
+    'error',
+    'skip',
+    'force',
+    'create',
+    'invoke',
+    'conflict',
+    'identical',
+    'info',
+    'table'
+  ].forEach(function (methodName) {
+    this.log[methodName] = sinon.spy();
+  }, this);
+
+}
+
+module.exports = {
+  DummyPrompt: DummyPrompt,
+  TestAdapter: TestAdapter
+};

--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -13,6 +13,7 @@ var yeoman = require('yeoman-environment');
 var assert = require('./assert');
 var generators = require('../..');
 var RunContext = require('../test/run-context');
+var adapter = require('../test/adapter');
 
 exports.decorated = [];
 
@@ -185,17 +186,9 @@ exports.mockPrompt = function (generator, answers) {
   var promptModule = generator.env.adapter.prompt;
   answers = answers || {};
 
-  var DummyPrompt = function (q) {
-    this.question = q;
-  };
-  DummyPrompt.prototype.run = function (cb) {
-    setTimeout(function () {
-      cb(answers[this.question.name] || this.question.default);
-    }.bind(this), 0);
-  };
-
+  var DummyPrompt = adapter.DummyPrompt;
   Object.keys(promptModule.prompts).forEach(function (name) {
-    promptModule.registerPrompt(name, DummyPrompt);
+    promptModule.registerPrompt(name, DummyPrompt.bind(DummyPrompt, answers));
   });
 };
 

--- a/lib/test/run-context.js
+++ b/lib/test/run-context.js
@@ -6,6 +6,7 @@ var yeoman = require('yeoman-environment');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var helpers = require('./helpers');
+var TestAdapter = require('./adapter').TestAdapter;
 
 /**
  * This class provide a run context object to façade the complexity involved in setting
@@ -54,7 +55,7 @@ RunContext.prototype._run = function () {
   this.runned = true;
 
   var namespace;
-  this.env = yeoman.createEnv();
+  this.env = yeoman.createEnv([], {}, new TestAdapter());
 
   helpers.registerDependencies(this.env, this.dependencies);
 


### PR DESCRIPTION
- Created `lib/test/adapter.js` that exposes both `DummyPrompt` and `TestAdapter` classes
- Refactored the use of `DummyPrompt` by `lib/test/helpers.js`
- `lib/test/run-context` now uses the `TestAdapter` instead of the original `TerminalAdapter`
- `TestAdapter` also added to `test/actions.js`, first step into converting some of the most verbose tests
