### PR TITLE
accept string in assert.fileContent and noFileContent

### DIFF
--- a/lib/test/assert.js
+++ b/lib/test/assert.js
@@ -118,11 +118,12 @@ assert.files = function (files) {
 };
 
 /**
- * Assert that a file's content matches a regex
+ * Assert that a file's content matches a regex or string
  * @param  {String}       file     - path to a file
- * @param  {Regex}        reg      - regex that will be used to search the file
+ * @param  {Regex,String} reg      - regex / string that will be used to search the file
  * @example
  * assert.fileContent('models/user.js', /App\.User = DS\.Model\.extend/);
+ * assert.fileContent('models/user.js', 'App.User = DS.Model.extend');
  *
  * @also
  *
@@ -144,16 +145,21 @@ assert.fileContent = function () {
     var regex = pair[1];
     assert.file(file);
     var body = fs.readFileSync(file, 'utf8');
-    assert.ok(regex.test(body), file + ' did not match \'' + regex + '\'.');
+    if (typeof regex === 'string') {
+      assert.ok(body.indexOf(regex) > -1, file + ' did not match \'' + regex + '\'.');
+    } else {
+      assert.ok(regex.test(body), file + ' did not match \'' + regex + '\'.');
+    }
   });
 };
 
 /**
- * Assert that a file's content does not match a regex
+ * Assert that a file's content does not match a regex / string
  * @param  {String}       file     - path to a file
- * @param  {Regex}        reg      - regex that will be used to search the file
+ * @param  {Regex,String} reg      - regex / string that will be used to search the file
  * @example
  * assert.noFileContent('models/user.js', /App\.User = DS\.Model\.extend/);
+ * assert.noFileContent('models/user.js', 'App.User = DS.Model.extend');
  *
  * @also
  *
@@ -174,7 +180,11 @@ assert.noFileContent = function () {
     var regex = pair[1];
     assert.file(file);
     var body = fs.readFileSync(file, 'utf8');
-    assert.ok(!regex.test(body), file + ' matched \'' + regex + '\'.');
+    if (typeof regex === 'string') {
+      assert.ok(body.indexOf(regex) === -1, file + ' matched \'' + regex + '\'.');
+    } else {
+      assert.ok(!regex.test(body), file + ' matched \'' + regex + '\'.');
+    }
   });
 };
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -96,8 +96,16 @@ describe('generators.assert', function () {
       assert.doesNotThrow(yo.assert.fileContent.bind(yo.assert, 'testFile', /Roses are red/));
     });
 
+    it('accept a file and string when the file contains the string', function () {
+      assert.doesNotThrow(yo.assert.fileContent.bind(yo.assert, 'testFile', 'Roses are red'));
+    });
+
     it('reject a file and regex when the file content does not match the regex', function () {
       assert.throws(yo.assert.fileContent.bind(yo.assert, 'testFile', /Roses are blue/));
+    });
+
+    it('reject a file and string when the file content does not contain the string', function () {
+      assert.throws(yo.assert.fileContent.bind(yo.assert, 'testFile', 'Roses are blue'));
     });
 
     it('accept an array of file/regex pairs when each file\'s content matches the corresponding regex', function () {
@@ -122,8 +130,16 @@ describe('generators.assert', function () {
       assert.doesNotThrow(yo.assert.noFileContent.bind(yo.assert, 'testFile', /Roses are blue/));
     });
 
+    it('accept a file and string when the file content does not contain the string', function () {
+      assert.doesNotThrow(yo.assert.noFileContent.bind(yo.assert, 'testFile', 'Roses are blue'));
+    });
+
     it('reject a file and regex when the file content matches the regex', function () {
       assert.throws(yo.assert.noFileContent.bind(yo.assert, 'testFile', /Roses are red/));
+    });
+
+    it('reject a file and string when the file content contain the string', function () {
+      assert.throws(yo.assert.noFileContent.bind(yo.assert, 'testFile', 'Roses are red'));
     });
 
     it('accept an array of file/regex pairs when each file\'s content does not match its corresponding regex', function () {


### PR DESCRIPTION
With this PR it's possible to check the file content with a simple string.

This is more readable:
`assert.noFileContent('models/user.js', 'App.User = DS.Model.extend');`

than:
`assert.noFileContent('models/user.js', /App\.User = DS\.Model\.extend/);`

I made the change such that the previous behaviour still works :wink: 
