### PR TITLE
passing options instead of cb to spawnCommand

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -33,7 +33,7 @@ install.runInstall = function (installer, paths, options, cb) {
   this.emit(installer + 'Install', paths);
   var args = ['install'].concat(paths).concat(dargs(options));
 
-  this.spawnCommand(installer, args, cb)
+  this.spawnCommand(installer, args, options)
     .on('error', cb)
     .on('exit', this.emit.bind(this, installer + 'Install:end', paths))
     .on('exit', function (err) {


### PR DESCRIPTION
I was puzzled by why 'cb' was being passed to the spawnCommand method. I assume this was a typo? With the proposed change, you can now pass in options to the spawned command in order to do things like modify the PATH variable for the spawn'd process, etc.
