### PR TITLE
store prompt answers in a global config file

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -11,12 +11,14 @@ var chalk = require('chalk');
 var file = require('file-utils');
 var nopt = require('nopt');
 var through = require('through2');
+var userHome = require('user-home');
+var GruntfileEditor = require('gruntfile-editor');
+var FileEditor = require('mem-fs-editor');
 
 var engines = require('./util/engines');
 var Conflicter = require('./util/conflicter');
 var Storage = require('./util/storage');
-var GruntfileEditor = require('gruntfile-editor');
-var FileEditor = require('mem-fs-editor');
+var promptSuggestion = require('./util/prompt-suggestion');
 
 var fileLogger = { write: _.noop, warn: _.noop };
 
@@ -87,6 +89,12 @@ var Base = module.exports = function Base(args, options) {
     desc: 'Print generator\'s options and usage'
   });
 
+  this.option('skip-cache', {
+    type: Boolean,
+    desc: 'Do not remember prompt answers',
+    defaults: false
+  });
+
   // checks required paramaters
   assert(this.options.env, 'You must provide the environment object. Use env#create() to create a new generator.');
   assert(this.options.resolved, 'You must provide the resolved path value. Use env#create() to create a new generator.');
@@ -148,7 +156,8 @@ var Base = module.exports = function Base(args, options) {
   this.dest.registerValidationFilter('collision', this.getCollisionFilter());
   this.src.registerValidationFilter('collision', this.getCollisionFilter());
 
-  this._setStorage();
+  this.config = this._getStorage();
+  this._globalConfig = this._getGlobalStorage();
 
   // ensure source/destination path, can be configured from subclasses
   this.sourceRoot(path.join(path.dirname(this.resolved), 'templates'));
@@ -191,7 +200,18 @@ _.extend(Base.prototype, require('./util/common'));
 Base.prototype.user = require('./actions/user');
 
 Base.prototype.prompt = function (questions, callback) {
-  this.env.adapter.prompt(questions, callback);
+  questions = promptSuggestion.prefillQuestions(this._globalConfig, questions);
+
+  this.env.adapter.prompt(questions, function (answers) {
+    if (!this.options['skip-cache']) {
+      promptSuggestion.storeAnswers(this._globalConfig, questions, answers);
+    }
+
+    if (_.isFunction(callback)) {
+      callback(answers);
+    }
+  }.bind(this));
+
   return this;
 };
 
@@ -579,21 +599,45 @@ Base.prototype.composeWith = function composeWith(namespace, options, settings) 
 
 /**
  * Determine the root generator name (the one who's extending Base).
+ * @return {String} The name of the root generator
  */
 
 Base.prototype.rootGeneratorName = function () {
   var filepath = findup('package.json', { cwd: this.resolved });
-  return filepath ? JSON.parse(fs.readFileSync(filepath, 'utf8')).name : '*';
+  return filepath ? this.fs.readJSON(filepath).name : '*';
 };
 
 /**
- * Setup a storage instance.
+ * Determine the root generator version (the one who's extending Base).
+ * @return {String} The version of the root generator
+ */
+
+Base.prototype.rootGeneratorVersion = function () {
+  var filepath = findup('package.json', { cwd: this.resolved });
+  return filepath ? this.fs.readJSON(filepath).version : '0.0.0';
+};
+
+/**
+ * Return a storage instance.
+ * @return {Storage} Generator storage
  * @private
  */
 
-Base.prototype._setStorage = function () {
+Base.prototype._getStorage = function () {
   var storePath = path.join(this.destinationRoot(), '.yo-rc.json');
-  this.config = new Storage(this.rootGeneratorName(), storePath);
+  return new Storage(this.rootGeneratorName(), storePath);
+};
+
+/**
+ * Setup a globalConfig storage instance.
+ * @return {Storage} Global config storage
+ * @private
+ */
+
+Base.prototype._getGlobalStorage = function () {
+  var storePath = path.join(userHome, '.yo-rc-global.json');
+  var storeName = util.format('%s:%s', this.rootGeneratorName(), this.rootGeneratorVersion());
+  return new Storage(storeName, storePath);
 };
 
 /**
@@ -615,7 +659,7 @@ Base.prototype.destinationRoot = function (rootPath) {
     process.chdir(rootPath);
 
     // Reset the storage
-    this._setStorage();
+    this.config = this._getStorage();
   }
 
   return this._destinationRoot || process.cwd();

--- a/lib/util/prompt-suggestion.js
+++ b/lib/util/prompt-suggestion.js
@@ -1,0 +1,178 @@
+'use strict';
+
+var assert = require('assert');
+var _ = require('lodash');
+
+/**
+ * @mixin
+ * @alias util/prompt-suggestion
+ */
+var promptSuggestion = module.exports;
+
+/**
+ * Returns the default value for a checkbox.
+ *
+ * @param  {Object} question Inquirer prompt item
+ * @param  {*} defaultValue  The stored default value
+ * @return {*}               Default value to set
+ * @private
+ */
+var getCheckboxDefault = function (question, defaultValue) {
+  // For simplicity we uncheck all boxes and
+  // use .default to set the active ones.
+  _.each(question.choices, function (choice) {
+    if (typeof choice === 'object') {
+      choice.checked = false;
+    }
+  });
+  return defaultValue;
+};
+
+/**
+ * Returns the default value for a list.
+ *
+ * @param  {Object} question    Inquirer prompt item
+ * @param  {*} defaultValue     The stored default value
+ * @return {*}                  Default value to set
+ * @private
+ */
+var getListDefault = function (question, defaultValue) {
+  var choiceValues = _.map(question.choices, function (choice) {
+    if (typeof choice === 'object') {
+      return choice.value;
+    } else {
+      return choice;
+    }
+  });
+  return choiceValues.indexOf(defaultValue);
+};
+
+/**
+ * Return true if the answer should be store in
+ * the global store, otherwise false.
+ *
+ * @param  {Object}       question Inquirer prompt item
+ * @param  {String|Array} answer   The inquirer answer
+ * @return {Boolean}               Answer to be stored
+ * @private
+ */
+var storeListAnswer = function (question, answer) {
+  var choiceValues = _.pluck(question.choices, 'value');
+  var choiceIndex = choiceValues.indexOf(answer);
+  // Check if answer is not equal to default value
+  if (question.default !== choiceIndex) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Return true if the answer should be store in
+ * the global store, otherwise false.
+ *
+ * @param  {Object}       question Inquirer prompt item
+ * @param  {String|Array} answer   The inquirer answer
+ * @return {Boolean}               Answer to be stored
+ * @private
+ */
+var storeAnswer = function (question, answer) {
+  // Check if answer is not equal to default value or is undefined
+  if (answer && question.default !== answer) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Prefill the defaults with values from the global store.
+ *
+ * @param  {Store}        store     `.yo-rc-global` global config
+ * @param  {Array|Object} questions Original prompt questions
+ * @return {Array}                  Prompt questions array with prefilled values.
+ */
+promptSuggestion.prefillQuestions = function (store, questions) {
+  assert(store, 'A store parameter is required');
+  assert(questions, 'A questions parameter is required');
+
+  var promptValues = store.get('promptValues') || {};
+
+  questions = _.cloneDeep(questions);
+
+  if (!Array.isArray(questions)) {
+    questions = [questions];
+  }
+
+  // Write user defaults back to prompt
+  return questions.map(function (question) {
+    if (question.store !== true) return question;
+
+    var storedValue = promptValues[question.name];
+    if (storedValue == null) return question;
+
+    // Override prompt default with the user's default
+    switch (question.type) {
+
+      case 'rawlist':
+      case 'expand':
+        question.default = getListDefault(question, storedValue);
+        break;
+      case 'checkbox':
+        question.default = getCheckboxDefault(question, storedValue);
+        break;
+      default:
+        question.default = storedValue;
+        break;
+    }
+    return question;
+  }.bind(this));
+};
+
+/**
+ * Store the answers in the global store.
+ *
+ * @param  {Store}        store     `.yo-rc-global` global config
+ * @param  {Array|Object} questions Original prompt questions
+ * @param  {Object}       answers   The inquirer answers
+ */
+promptSuggestion.storeAnswers = function (store, questions, answers) {
+  assert(store, 'A store parameter is required');
+  assert(answers, 'A answers parameter is required');
+  assert(questions, 'A questions parameter is required');
+  assert.ok(_.isObject(answers), 'answers must be a object');
+
+  var promptValues = store.get('promptValues') || {};
+
+  if (!Array.isArray(questions)) {
+    questions = [questions];
+  }
+
+  _.each(questions, function (question) {
+    if (question.store !== true) return;
+
+    var saveAnswer;
+    var key = question.name;
+    var answer = answers[key];
+
+    switch (question.type) {
+
+      case 'rawlist':
+      case 'expand':
+        saveAnswer = storeListAnswer(question, answer);
+        break;
+
+      default:
+        saveAnswer = storeAnswer(question, answer);
+        break;
+    }
+
+    if (saveAnswer) {
+      promptValues[key] = answer;
+    }
+
+  }.bind(this));
+
+  if (Object.keys(promptValues).length) {
+    store.set('promptValues', promptValues);
+    store.save();
+  }
+};

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "text-table": "^0.2.0",
     "through2": "^0.6.3",
     "underscore.string": "^2.3.1",
+    "user-home": "^1.1.0",
     "xdg-basedir": "^1.0.0",
     "yeoman-environment": "yeoman/environment#mem-fs"
   },

--- a/test/base.js
+++ b/test/base.js
@@ -662,6 +662,7 @@ describe('generators.Base', function () {
         '',
         'Options:',
         '-h, --help # Print generator\'s options and usage',
+        '--skip-cache # Do not remember prompt answers Default: false',
         '--hook1 # Hook1 to be invoked',
         '--hook2 # Hook2 to be invoked',
         '--hook3 # Hook3 to be invoked',
@@ -711,14 +712,14 @@ describe('generators.Base', function () {
     });
 
     it('is updated when destinationRoot change', function () {
-      sinon.spy(this.Dummy.prototype, '_setStorage');
+      sinon.spy(this.Dummy.prototype, '_getStorage');
       this.dummy.destinationRoot('foo');
-      assert.equal(this.Dummy.prototype._setStorage.callCount, 1);
+      assert.equal(this.Dummy.prototype._getStorage.callCount, 1);
       this.dummy.destinationRoot();
-      assert.equal(this.Dummy.prototype._setStorage.callCount, 1);
+      assert.equal(this.Dummy.prototype._getStorage.callCount, 1);
       this.dummy.destinationRoot('foo');
-      assert.equal(this.Dummy.prototype._setStorage.callCount, 2);
-      this.Dummy.prototype._setStorage.restore();
+      assert.equal(this.Dummy.prototype._getStorage.callCount, 2);
+      this.Dummy.prototype._getStorage.restore();
     });
   });
 
@@ -901,4 +902,33 @@ describe('generators.Base', function () {
     });
   });
 
+  describe('#rootGeneratorName', function () {
+    afterEach(function () {
+      rimraf.sync('package.json');
+    });
+
+    it('returns the default name', function () {
+      assert.equal(this.dummy.rootGeneratorName(), '*');
+    });
+
+    it('returns generator name', function () {
+      fs.writeFileSync('package.json', '{ "name": "generator-name" }');
+      assert.equal(this.dummy.rootGeneratorName(), 'generator-name');
+    });
+  });
+
+  describe('#rootGeneratorVersion', function () {
+    afterEach(function () {
+      rimraf.sync('package.json');
+    });
+
+    it('returns the default version', function () {
+      assert.equal(this.dummy.rootGeneratorVersion(), '0.0.0');
+    });
+
+    it('returns generator version', function () {
+      fs.writeFileSync('package.json', '{ "version": "1.0.0" }');
+      assert.equal(this.dummy.rootGeneratorVersion(), '1.0.0');
+    });
+  });
 });

--- a/test/prompt-suggestion.js
+++ b/test/prompt-suggestion.js
@@ -1,0 +1,280 @@
+/*global describe, it, before, after, beforeEach, afterEach */
+'use strict';
+var path = require('path');
+var assert = require('assert');
+var os = require('os');
+var Storage = require('../lib/util/storage');
+var promptSuggestion = require('../lib/util/prompt-suggestion');
+var rimraf = require('rimraf');
+var inquirer = require('inquirer');
+
+describe('PromptSuggestion', function () {
+
+  beforeEach(function () {
+    this.storePath = path.join(os.tmpdir(), 'suggestion-config.json');
+    this.store = new Storage('suggestion', this.storePath);
+    this.store.set('promptValues', { respuesta: 'foo' });
+  });
+
+  afterEach(function (done) {
+    rimraf(this.storePath, done);
+  });
+
+  describe('.prefillQuestions()', function () {
+    it('require a store parameter', function () {
+      assert.throws(promptSuggestion.prefillQuestions.bind(null));
+    });
+
+    it('require a questions parameter', function () {
+      assert.throws(promptSuggestion.prefillQuestions.bind(this.store));
+    });
+
+    it('take a questions parameter', function () {
+      promptSuggestion.prefillQuestions(this.store, []);
+    });
+
+    it('take a question object', function () {
+      var question = {
+        name: 'respuesta',
+        default: 'bar',
+        store: true
+      };
+      var result = promptSuggestion.prefillQuestions(this.store, question)[0];
+
+      assert.equal(result.default, 'foo');
+    });
+
+    it('take a question array', function () {
+      var question = [{
+        name: 'respuesta',
+        default: 'bar',
+        store: true
+      }];
+      var result = promptSuggestion.prefillQuestions(this.store, question)[0];
+
+      assert.equal(result.default, 'foo');
+    });
+
+    it('don\'t override default when store is set to false', function () {
+      var question = {
+        name: 'respuesta',
+        default: 'bar',
+        store: false
+      };
+      var result = promptSuggestion.prefillQuestions(this.store, question)[0];
+      assert.equal(result.default, 'bar');
+    });
+
+    it('override default when store is set to true', function () {
+      var question = {
+        name: 'respuesta',
+        default: 'bar',
+        store: true
+      };
+      var result = promptSuggestion.prefillQuestions(this.store, question)[0];
+      assert.equal(result.default, 'foo');
+    });
+
+    describe('take a checkbox', function () {
+      beforeEach(function () {
+        this.store.set('promptValues', {
+          respuesta: ['foo']
+        });
+      });
+
+      it('override default from an array with objects', function () {
+        var question = {
+          type: 'checkbox',
+          name: 'respuesta',
+          default: ['bar'],
+          store: true,
+          choices: [{
+            value: 'foo',
+            name: 'foo'
+          }, new inquirer.Separator('spacer'), {
+            value: 'bar',
+            name: 'bar'
+          }, {
+            value: 'baz',
+            name: 'baz'
+          }]
+        };
+        var result = promptSuggestion.prefillQuestions(this.store, question)[0];
+
+        result.choices.forEach(function (choice) {
+          assert.equal(choice.checked, false);
+        });
+        assert.deepEqual(result.default, ['foo']);
+      });
+
+      it('override default from an array with strings', function () {
+        var question = {
+          type: 'checkbox',
+          name: 'respuesta',
+          default: ['bar'],
+          store: true,
+          choices: ['foo', new inquirer.Separator('spacer'), 'bar', 'baz']
+        };
+        var result = promptSuggestion.prefillQuestions(this.store, question)[0];
+
+        assert.deepEqual(result.default, ['foo']);
+      });
+
+      describe('with multiple defaults', function () {
+        beforeEach(function () {
+          this.store.set('promptValues', {
+            respuesta: ['foo', 'bar']
+          });
+        });
+
+        it('from an array with objects', function () {
+          var question = {
+            type: 'checkbox',
+            name: 'respuesta',
+            default: ['bar'],
+            store: true,
+            choices: [{
+              value: 'foo',
+              name: 'foo'
+            }, new inquirer.Separator('spacer'), {
+              value: 'bar',
+              name: 'bar'
+            }, {
+              value: 'baz',
+              name: 'baz'
+            }]
+          };
+          var result = promptSuggestion.prefillQuestions(this.store, question)[0];
+
+          result.choices.forEach(function (choice) {
+            assert.equal(choice.checked, false);
+          });
+          assert.deepEqual(result.default, ['foo', 'bar']);
+        });
+
+        it('from an array with strings', function () {
+          var question = {
+            type: 'checkbox',
+            name: 'respuesta',
+            default: ['bar'],
+            store: true,
+            choices: ['foo', new inquirer.Separator('spacer'), 'bar', 'baz']
+          };
+          var result = promptSuggestion.prefillQuestions(this.store, question)[0];
+
+          assert.deepEqual(result.default, ['foo', 'bar']);
+        });
+      });
+    });
+
+    describe('take a rawlist / expand', function () {
+      beforeEach(function () {
+        this.store.set('promptValues', {
+          respuesta: 'bar'
+        });
+      });
+
+      it('override default arrayWithObjects', function () {
+        var question = {
+          type: 'rawlist',
+          name: 'respuesta',
+          default: 0,
+          store: true,
+          choices: [{
+            value: 'foo',
+            name: 'foo'
+          }, new inquirer.Separator('spacer'), {
+            value: 'bar',
+            name: 'bar'
+          }, {
+            value: 'baz',
+            name: 'baz'
+          }]
+        };
+        var result = promptSuggestion.prefillQuestions(this.store, question)[0];
+
+        assert.equal(result.default, 2);
+      });
+
+      it('override default arrayWithObjects', function () {
+        var question = {
+          type: 'rawlist',
+          name: 'respuesta',
+          default: 0,
+          store: true,
+          choices: ['foo', new inquirer.Separator('spacer'), 'bar', 'baz']
+        };
+        var result = promptSuggestion.prefillQuestions(this.store, question)[0];
+
+        assert.equal(result.default, 2);
+      });
+    });
+  });
+
+  describe('.storeAnswers()', function () {
+    beforeEach(function () {
+      this.store.set('promptValues', { respuesta: 'foo' });
+    });
+
+    it('require a store parameter', function () {
+      assert.throws(promptSuggestion.storeAnswers.bind(null));
+    });
+
+    it('require a question parameter', function () {
+      assert.throws(promptSuggestion.storeAnswers.bind(this.store));
+    });
+
+    it('require a answer parameter', function () {
+      assert.throws(promptSuggestion.storeAnswers.bind(this.store, []));
+    });
+
+    it('take a answer parameter', function () {
+      promptSuggestion.storeAnswers(this.store, [], {});
+    });
+
+    it('store answer in global store', function () {
+      var question = {
+        name: 'respuesta',
+        default: 'bar',
+        store: true
+      };
+      var mockAnswers = {
+        respuesta: 'baz'
+      };
+      promptSuggestion.prefillQuestions(this.store, question);
+      promptSuggestion.storeAnswers(this.store, question, mockAnswers);
+
+      assert.equal(this.store.get('promptValues').respuesta, 'baz');
+    });
+
+    it('don\'t store answer in global store', function () {
+      var question = {
+        name: 'respuesta',
+        default: 'bar',
+        store: false
+      };
+      var mockAnswers = {
+        respuesta: 'baz'
+      };
+      promptSuggestion.prefillQuestions(this.store, question);
+      promptSuggestion.storeAnswers(this.store, question, mockAnswers);
+      assert.equal(this.store.get('promptValues').respuesta, 'foo');
+    });
+
+    it('store answer from rawlist type', function () {
+      var question = {
+        type: 'rawlist',
+        name: 'respuesta',
+        default: 0,
+        store: true,
+        choices: ['foo', new inquirer.Separator('spacer'), 'bar', 'baz']
+      };
+      var mockAnswers = {
+        respuesta: 'baz'
+      };
+      promptSuggestion.prefillQuestions(this.store, question);
+      promptSuggestion.storeAnswers(this.store, question, mockAnswers);
+      assert.equal(this.store.get('promptValues').respuesta, 'baz');
+    });
+  });
+});


### PR DESCRIPTION
In addition to this previous Pull Request https://github.com/yeoman/generator/pull/579.

This Pull Request, adds the ability to save the answers from a inquire prompt in a global config file `.yo-rc-global.json`. The answer will be set in the future as the default answer. 

To enable this feature just set `store: true` on each prompt which you want to save. The default value is set to `false`.

```
var prompts = [{
    type: 'input',
    name: 'githubUsername',
    message: 'What is your GitHub username',
    store: true
  },
  {
    type: 'list',
    name: 'licence',
    message: 'Choose a licence',
    choices: ['MIT', 'GPL', 'Apache'],
    store: true
  },{
    type: 'password',
    name: 'password',
    message: 'Your password'
    // Will not saved
  }
];

this.prompt(prompts, callback);
```

You can clear the global cache directly from your yo cli. Take a look at the related PullRequest https://github.com/yeoman/yo/pull/227
