### PR TITLE
`.jshintrc`: remove deprecated options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,9 +11,6 @@
   "noarg": true,
   "undef": true,
   "strict": true,
-  "trailing": true,
-  "smarttabs": true,
-  "indent": 2,
   "quotmark": "single",
   "scripturl": true
 }


### PR DESCRIPTION
The `trailing`, `indent` and `smarttabs` JSHint options are deprecated since JSHint v2.5
