### PR TITLE
Fix default assignment in spawn_command

### DIFF
--- a/lib/actions/spawn_command.js
+++ b/lib/actions/spawn_command.js
@@ -14,5 +14,5 @@ var spawn = require('cross-spawn');
 
 module.exports = function spawnCommand(command, args, opt) {
   opt = opt || {};
-  return spawn(command, args, _.defaults({ stdio: 'inherit' }, opt));
+  return spawn(command, args, _.defaults(opt, { stdio: 'inherit' }));
 };


### PR DESCRIPTION
Pass default values as second argument so it's possible to override it.
