### PR TITLE
Fix mockPrompt's handling of falsy answers

### DIFF
--- a/lib/test/adapter.js
+++ b/lib/test/adapter.js
@@ -11,9 +11,26 @@ function DummyPrompt(answers, q) {
 }
 
 DummyPrompt.prototype.run = function (cb) {
+  var answer = this.answers[this.question.name];
+
+  var isSet;
+  switch (this.question.type) {
+    case 'list':
+      // list prompt accepts any answer value including null
+      isSet = answer !== undefined;
+      break;
+    default:
+      // other prompts treat all falsy values to default
+      isSet = !!answer;
+  }
+
+  if (!isSet) {
+    answer = this.question.default;
+  }
+
   setImmediate(function () {
-    cb(this.answers[this.question.name] || this.question.default);
-  }.bind(this));
+    cb(answer);
+  });
 };
 
 function TestAdapter(answers) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -148,6 +148,28 @@ describe('generators.test', function () {
       });
     });
 
+    it('supports `null` answer for `list` type', function (done) {
+      var generator = env.instantiate(helpers.createDummyGenerator());
+      helpers.mockPrompt(generator, {
+        respuesta: null
+      });
+      generator.prompt([{ name: 'respuesta', message: 'foo', type: 'list', default: 'bar' }], function (answers) {
+        assert.equal(answers.respuesta, null);
+        done();
+      });
+    });
+
+    it('treats `null` as no answer for `input` type', function (done) {
+      var generator = env.instantiate(helpers.createDummyGenerator());
+      helpers.mockPrompt(generator, {
+        respuesta: null
+      });
+      generator.prompt([{ name: 'respuesta', message: 'foo', type: 'input', default: 'bar' }], function (answers) {
+        assert.equal(answers.respuesta, 'bar');
+        done();
+      });
+    });
+
     it('prefers mocked values over defaults', function (done) {
       this.generator.prompt([{ name: 'answer', type: 'input', default: 'bar' }], function (answers) {
         assert.equal(answers.answer, 'foo');


### PR DESCRIPTION
Fix `mockPrompt` and `DummyPrompt` to copy Inquirer's behaviour when
dealing with falsy answers.
- The `list` prompt treats all values including `null` and `false`
  as a valid response.
- All other prompts are kept unchanged, they replace every falsy
  answer with the default value.

---

I have run into this issue while upgrading from yeoman-generator v0.16 to v0.18. 

My generator uses a `list` prompt to select a model name from a list of know models, plus there is an extra option `{ name: '(custom)', value: null }` allowing the user to enter arbitrary value in the next prompt.

The code works when invoked via `yo`. The tests are failing because `null` is treated as "use default" now.
