### PR TITLE
Fix mockPrompt's default for confirm prompts

### DIFF
--- a/lib/test/adapter.js
+++ b/lib/test/adapter.js
@@ -26,6 +26,9 @@ DummyPrompt.prototype.run = function (cb) {
 
   if (!isSet) {
     answer = this.question.default;
+    if (answer === undefined && this.question.type === 'confirm') {
+      answer = true;
+    }
   }
 
   setImmediate(function () {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -170,6 +170,15 @@ describe('generators.test', function () {
       });
     });
 
+    it('uses `true` as the default value for `confirm` type', function (done) {
+      var generator = env.instantiate(helpers.createDummyGenerator());
+      helpers.mockPrompt(generator, {});
+      generator.prompt([{ name: 'respuesta', message: 'foo', type: 'confirm' }], function (answers) {
+        assert.equal(answers.respuesta, true);
+        done();
+      });
+    });
+
     it('prefers mocked values over defaults', function (done) {
       this.generator.prompt([{ name: 'answer', type: 'input', default: 'bar' }], function (answers) {
         assert.equal(answers.answer, 'foo');


### PR DESCRIPTION
One more `mockPrompt` fix: use `true` as the default value for prompts of type `confirm`.
