### PR TITLE
Fix mockPrompt for `false` response to `confirm`

### DIFF
--- a/lib/test/adapter.js
+++ b/lib/test/adapter.js
@@ -19,6 +19,10 @@ DummyPrompt.prototype.run = function (cb) {
       // list prompt accepts any answer value including null
       isSet = answer !== undefined;
       break;
+    case 'confirm':
+      // ensure that we don't replace `false` with default `true`
+      isSet = answer || answer === false;
+      break;
     default:
       // other prompts treat all falsy values to default
       isSet = !!answer;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -179,6 +179,15 @@ describe('generators.test', function () {
       });
     });
 
+    it('supports `false` answer for `confirm` type', function (done) {
+      var generator = env.instantiate(helpers.createDummyGenerator());
+      helpers.mockPrompt(generator, { respuesta: false });
+      generator.prompt([{ name: 'respuesta', message: 'foo', type: 'confirm' }], function (answers) {
+        assert.equal(answers.respuesta, false);
+        done();
+      });
+    });
+
     it('prefers mocked values over defaults', function (done) {
       this.generator.prompt([{ name: 'answer', type: 'input', default: 'bar' }], function (answers) {
         assert.equal(answers.answer, 'foo');


### PR DESCRIPTION
Fix `mockPrompt` and `DummyPrompt` so they do not replace `false`
with the default value (which is `true`).

This patch fixes a regression introduced by #712. I apologise for that.
