### PR TITLE
Add method to terminate the install process

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -37,13 +37,26 @@ install.runInstall = function (installer, paths, options, cb) {
   var args = ['install'].concat(paths).concat(dargs(options));
 
   this.env.runLoop.add('install', function (done) {
+    if (this._installTerminated) {
+      // Installation was terminated and any furhter commands
+      // will be ignored. Run the generator again to unlock.
+      return;
+    }
     this.emit(installer + 'Install', paths);
-    this.spawnCommand(installer, args, options)
+
+    // Create install process
+    this.installChildProcess = this.spawnCommand(installer, args, options)
       .on('error', cb)
       .on('exit', function (err) {
+        this.installChildProcess = null;
+
         if (err === 127) {
           this.log.error('Could not find ' + installer + '. Please install with ' +
                               '`npm install -g ' + installer + '`.');
+        } else if (err === 130) {
+          // Installation was terminated by signal and
+          // we don't want to emit any further events.
+          return;
         }
         this.emit(installer + 'Install:end', paths);
         cb(err);
@@ -156,4 +169,18 @@ install.bowerInstall = function install(cmpnt, options, cb) {
 
 install.npmInstall = function install(pkgs, options, cb) {
   return this.runInstall('npm', pkgs, options, cb);
+};
+
+/**
+ * Terminate the installation process for all package managers immediately.
+ * After that a `install:terminated` will be emitted.
+ */
+install.terminateInstall = function terminateInstall() {
+  if (!this._installTerminated) {
+    this._installTerminated = true;
+    this.emit('install:terminated');
+  }
+
+  if (!this.installChildProcess) return;
+  this.installChildProcess.kill('SIGKILL');
 };

--- a/lib/base.js
+++ b/lib/base.js
@@ -364,6 +364,7 @@ Base.prototype.checkRequiredArgs = function () {
 Base.prototype.run = function run(args, cb) {
   var self = this;
   this._running = true;
+  this._installTerminated = false;
   this.emit('run');
 
   if (!cb) {

--- a/test/install.js
+++ b/test/install.js
@@ -11,7 +11,11 @@ var asyncStub = {
     if (key === 'exit') {
       cb();
     }
+    this[key] = cb;
     return asyncStub;
+  },
+  kill: function () {
+    this.exit(130);
   }
 };
 
@@ -135,6 +139,40 @@ describe('generators.Base (actions/install mixin)', function () {
     it('accept and execute a function as its only argument', function (done) {
       this.dummy.installDependencies(done);
       this.dummy.run();
+    });
+  });
+
+  describe('#terminateInstall()', function () {
+
+    it('terminate at start', function (done) {
+      var neverCalled = sinon.stub();
+      this.dummy.on('install:terminated', done);
+      this.dummy.on('bowerInstall:end', neverCalled);
+      this.dummy.on('npmInstall:end', neverCalled);
+      this.dummy.run(neverCalled);
+      this.dummy.terminateInstall();
+      this.dummy.installDependencies();
+    });
+
+    it('terminate after bower', function (done) {
+      var neverCalled = sinon.stub();
+      this.dummy.on('install:terminated', done);
+      this.dummy.on('bowerInstall:end', this.dummy.terminateInstall);
+      this.dummy.on('npmInstall:end', neverCalled);
+      this.dummy.run(neverCalled);
+      this.dummy.installDependencies();
+    });
+
+    it('execute run after terminate', function (done) {
+      var installEnd = sinon.stub();
+      this.dummy.on('bowerInstall:end', installEnd);
+      this.dummy.on('npmInstall:end', installEnd);
+      this.dummy.terminateInstall();
+      this.dummy.installDependencies();
+      this.dummy.run(function () {
+        sinon.assert.calledTwice(installEnd);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
To integrate yeoman in external tools like atom-shell, yeoman should provide a mechanism to terminate yeoman childs process like `npm install` and/or `bower install`. This PR brings in this feature. The API is simple, just call `terminateInstall()` at some point. This will terminate the current installation process and lock any further processes. To reactivate it you must execute `run()` again.

``` js
var gen = env.run('polymer');
gen.on('install:terminated', function() {
  console.log('Installation was terminated');
});
gen.installDependencies();
gen.terminateInstall();
```
