### PR TITLE
Fix conflicter by removing toString() call

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -760,7 +760,7 @@ Base.prototype._writeFiles = function (done) {
       return cb();
     }
 
-    self.conflicter.checkForCollision(file.path, file.contents.toString(), function (err, status) {
+    self.conflicter.checkForCollision(file.path, file.contents, function (err, status) {
       if (err) return cb(err);
       if (status !== 'skip') {
         stream.push(file);

--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -165,7 +165,7 @@ Conflicter.prototype._ask = function (file, cb) {
     }
 
     if (result.action === 'diff') {
-      this.adapter.diff(fs.readFileSync(file.path, 'utf8'), file.contents);
+      this.adapter.diff(fs.readFileSync(file.path, 'utf8'), file.contents.toString());
       return this._ask(file, cb);
     }
 


### PR DESCRIPTION
detect-conflict dependency handles buffers properly, so this toString() call is not required anymore and cause false positive on conflicter.

Close #717