### PR TITLE
Replace isbinaryfile with istextorbinary

### DIFF
--- a/lib/actions/actions.js
+++ b/lib/actions/actions.js
@@ -2,7 +2,7 @@
 var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
-var isBinaryFile = require('isbinaryfile');
+var istextorbinary = require('istextorbinary');
 var chalk = require('chalk');
 var xdgBasedir = require('xdg-basedir');
 var engine = require('../util/engines').underscore;
@@ -23,7 +23,6 @@ actions.cacheRoot = function cacheRoot() {
 
 // Copy helper for two versions of copy action
 actions._prepCopy = function _prepCopy(source, destination, process) {
-  var body;
   destination = destination || source;
 
   if (typeof destination === 'function') {
@@ -35,17 +34,18 @@ actions._prepCopy = function _prepCopy(source, destination, process) {
   destination = this.isPathAbsolute(destination) ? destination : path.join(this.destinationRoot(), destination);
 
   var encoding = null;
-  var binary = isBinaryFile(source);
-  if (!binary) {
-    encoding = 'utf8';
-  }
+  var body = fs.readFileSync(source);
 
-  body = fs.readFileSync(source, encoding);
+  var isText = istextorbinary.isTextSync(undefined, body);
 
-  if (typeof process === 'function' && !binary) {
-    body = process(body, source, destination, {
-      encoding: encoding
-    });
+  if (isText) {
+    body = body.toString();
+
+    if (typeof process === 'function') {
+      body = process(body, source, destination, {
+        encoding: encoding
+      });
+    }
   }
 
   return {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "glob": "^4.3.2",
     "gruntfile-editor": "^0.2.0",
     "inquirer": "^0.8.0",
-    "isbinaryfile": "^2.0.0",
+    "istextorbinary": "^1.0.2",
     "lodash": "^2.4.1",
     "mem-fs-editor": "^1.0.0",
     "mime": "^1.2.9",


### PR DESCRIPTION
This avoid reading the file twice, and also drop one dependency when #737 is merged.

compared to [isbinaryfile](https://github.com/gjtorikian/isBinaryFile), [istextorbinary](https://github.com/bevry/istextorbinary) can handles a `Buffer` as input instead of filename.