### PR TITLE
PR on issue #742 withLocalConfig - basic tests & implementation

### DIFF
--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -216,7 +216,7 @@ exports.restorePrompt = function (generator) {
  * Provide mocked values to the config, by creating a .yo-rc.json in the testdirectory.
  * Needs to be called before the generator is created
  * @param  {Generator} generator - a Yeoman generator
- * @param  {Ojbect} localConfig - localConfig - should look just like if you called config.getAll()
+ * @param  {Ojbect} localConfig - localConfig - should look just like your .yo-rc.json content
  */
 exports.mockLocalConfig = function (generator, localConfig) {
   fs.writeFileSync('.yo-rc.json', JSON.stringify(localConfig, null, 2));

--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -213,6 +213,15 @@ exports.restorePrompt = function (generator) {
 };
 
 /**
+ * Provide mocked values to the config
+ * @param  {Generator} generator - a Yeoman generator
+ * @param  {Ojbect} localConfig - localConfig - should look just like if called config.getAll()
+ */
+exports.mockLocalConfig = function (generator, localConfig) {
+  generator.config.defaults(localConfig);
+};
+
+/**
  * Create a simple, dummy generator
  */
 

--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -213,13 +213,12 @@ exports.restorePrompt = function (generator) {
 };
 
 /**
- * Provide mocked values to the config, by creating a .yo-rc.json in the testdirectory.
- * Needs to be called before the generator is created
+ * Provide mocked values to the config
  * @param  {Generator} generator - a Yeoman generator
- * @param  {Ojbect} localConfig - localConfig - should look just like your .yo-rc.json content
+ * @param  {Ojbect} localConfig - localConfig - should look just like if called config.getAll()
  */
 exports.mockLocalConfig = function (generator, localConfig) {
-  fs.writeFileSync('.yo-rc.json', JSON.stringify(localConfig, null, 2));
+  generator.config.defaults(localConfig);
 };
 
 /**

--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -213,12 +213,13 @@ exports.restorePrompt = function (generator) {
 };
 
 /**
- * Provide mocked values to the config
+ * Provide mocked values to the config, by creating a .yo-rc.json in the testdirectory.
+ * Needs to be called before the generator is created
  * @param  {Generator} generator - a Yeoman generator
- * @param  {Ojbect} localConfig - localConfig - should look just like if called config.getAll()
+ * @param  {Ojbect} localConfig - localConfig - should look just like if you called config.getAll()
  */
 exports.mockLocalConfig = function (generator, localConfig) {
-  generator.config.defaults(localConfig);
+  fs.writeFileSync('.yo-rc.json', JSON.stringify(localConfig, null, 2));
 };
 
 /**

--- a/lib/test/run-context.js
+++ b/lib/test/run-context.js
@@ -78,6 +78,11 @@ RunContext.prototype._run = function () {
     this.env.registerStub(this.Generator, namespace);
   }
 
+  if (this.localConfig) { // only mock local config when withLocalConfig was called
+    console.log(namespace);
+    helpers.mockLocalConfig(this.generator, this.localConfig);
+  }
+
   this.generator = this.env.create(namespace, {
     arguments: this.args,
     options: _.extend({
@@ -86,10 +91,6 @@ RunContext.prototype._run = function () {
   });
 
   helpers.mockPrompt(this.generator, this.answers);
-
-  if (this.localConfig) { // only mock local config when withLocalConfig was called
-    helpers.mockLocalConfig(this.generator, this.localConfig);
-  }
 
   this.generator.on('error', this.emit.bind(this, 'error'));
   this.generator.once('end', function () {
@@ -203,7 +204,7 @@ RunContext.prototype.withGenerators = function (dependencies) {
 
 /**
  * mock the local configuration with the provided config
- * @param  {Object} localConfig - should look just like if called config.getAll()
+ * @param  {Object} localConfig - should look just like if you called config.getAll()
  * @return {this}
  */
 RunContext.prototype.withLocalConfig = function (localConfig) {

--- a/lib/test/run-context.js
+++ b/lib/test/run-context.js
@@ -79,7 +79,6 @@ RunContext.prototype._run = function () {
   }
 
   if (this.localConfig) { // only mock local config when withLocalConfig was called
-    console.log(namespace);
     helpers.mockLocalConfig(this.generator, this.localConfig);
   }
 
@@ -204,7 +203,7 @@ RunContext.prototype.withGenerators = function (dependencies) {
 
 /**
  * mock the local configuration with the provided config
- * @param  {Object} localConfig - should look just like if you called config.getAll()
+ * @param  {Object} localConfig - - should look just like your .yo-rc.json content
  * @return {this}
  */
 RunContext.prototype.withLocalConfig = function (localConfig) {

--- a/lib/test/run-context.js
+++ b/lib/test/run-context.js
@@ -29,6 +29,7 @@ var RunContext = module.exports = function RunContext(Generator, settings) {
   this.args = [];
   this.options = {};
   this.answers = {};
+  this.localConfig = null;
   this.dependencies = [];
   this.Generator = Generator;
   this.settings = _.extend({ tmpdir: true }, settings);
@@ -85,6 +86,10 @@ RunContext.prototype._run = function () {
   });
 
   helpers.mockPrompt(this.generator, this.answers);
+
+  if (this.localConfig) { // only mock local config when withLocalConfig was called
+    helpers.mockLocalConfig(this.generator, this.localConfig);
+  }
 
   this.generator.on('error', this.emit.bind(this, 'error'));
   this.generator.once('end', function () {
@@ -193,6 +198,17 @@ RunContext.prototype.withPrompt = RunContext.prototype.withPrompts;
 RunContext.prototype.withGenerators = function (dependencies) {
   assert(_.isArray(dependencies), 'dependencies should be an array');
   this.dependencies = this.dependencies.concat(dependencies);
+  return this;
+};
+
+/**
+ * mock the local configuration with the provided config
+ * @param  {Object} localConfig - should look just like if called config.getAll()
+ * @return {this}
+ */
+RunContext.prototype.withLocalConfig = function (localConfig) {
+  assert(_.isObject(localConfig), 'config should be an object');
+  this.localConfig = localConfig;
   return this;
 };
 

--- a/lib/test/run-context.js
+++ b/lib/test/run-context.js
@@ -78,10 +78,6 @@ RunContext.prototype._run = function () {
     this.env.registerStub(this.Generator, namespace);
   }
 
-  if (this.localConfig) { // only mock local config when withLocalConfig was called
-    helpers.mockLocalConfig(this.generator, this.localConfig);
-  }
-
   this.generator = this.env.create(namespace, {
     arguments: this.args,
     options: _.extend({
@@ -90,6 +86,10 @@ RunContext.prototype._run = function () {
   });
 
   helpers.mockPrompt(this.generator, this.answers);
+
+  if (this.localConfig) { // only mock local config when withLocalConfig was called
+    helpers.mockLocalConfig(this.generator, this.localConfig);
+  }
 
   this.generator.on('error', this.emit.bind(this, 'error'));
   this.generator.once('end', function () {
@@ -203,7 +203,7 @@ RunContext.prototype.withGenerators = function (dependencies) {
 
 /**
  * mock the local configuration with the provided config
- * @param  {Object} localConfig - - should look just like your .yo-rc.json content
+ * @param  {Object} localConfig - should look just like if called config.getAll()
  * @return {this}
  */
 RunContext.prototype.withLocalConfig = function (localConfig) {

--- a/test/run-context.js
+++ b/test/run-context.js
@@ -387,8 +387,10 @@ describe('RunContext', function () {
   describe('#withLocalConfig()', function () {
     it('provides config to the generator', function (done) {
       this.ctx.withLocalConfig({
-        some: true,
-        data: 'here'
+        '*': {
+          some: true,
+          data: 'here'
+        }
       }).on('ready', function () {
         assert.equal(this.ctx.generator.config.get('some'), true);
         assert.equal(this.ctx.generator.config.get('data'), 'here');

--- a/test/run-context.js
+++ b/test/run-context.js
@@ -387,10 +387,8 @@ describe('RunContext', function () {
   describe('#withLocalConfig()', function () {
     it('provides config to the generator', function (done) {
       this.ctx.withLocalConfig({
-        '*': {
-          some: true,
-          data: 'here'
-        }
+        some: true,
+        data: 'here'
       }).on('ready', function () {
         assert.equal(this.ctx.generator.config.get('some'), true);
         assert.equal(this.ctx.generator.config.get('data'), 'here');

--- a/test/run-context.js
+++ b/test/run-context.js
@@ -383,4 +383,17 @@ describe('RunContext', function () {
       }.bind(this));
     });
   });
+
+  describe('#withLocalConfig()', function () {
+    it('provides config to the generator', function (done) {
+      this.ctx.withLocalConfig({
+        some: true,
+        data: 'here'
+      }).on('ready', function () {
+        assert.equal(this.ctx.generator.config.get('some'), true);
+        assert.equal(this.ctx.generator.config.get('data'), 'here');
+        done();
+      }.bind(this));
+    });
+  });
 });


### PR DESCRIPTION
As discussed on issue #742 I created a PR:

Here's what I've done so far:

### test/run-context.js
write unit test for `withLocalConfig()` method


### lib/test/helpers.js
write a `mockLocalConfig()` function, that uses the generator's store's `default()` method to provide the config. This seemed an easy way to implement it, however I'm not sure whether it's a good idea to do so.


### lib/tests/run-context.js
extend the `RunContext` constructor, its `_run()` method and added a `withLocalConfig()` method to put everything together.
Notice how `helper.mockLocalConfig()`only gets called when `withLocalConfig()` was called? I needed to restrict this, since otherwise one of the tests would try to create a `.yo-rc.json` in `/` (root directory) and obviously would fail (I don't know why this happens though...).

Please let me know what you think.