### PR TITLE
Allow the Base generator to find non-enumerable methods

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -374,8 +374,9 @@ Base.prototype.run = function run(cb) {
   this._running = true;
   this.emit('run');
 
-  var methods = Object.keys(Object.getPrototypeOf(this));
-  assert(methods.length, 'This Generator is empty. Add at least one method for it to run.');
+  var methods = Object.getOwnPropertyNames(Object.getPrototypeOf(this));
+  var validMethods = methods.filter(methodIsValid);
+  assert(validMethods.length, 'This Generator is empty. Add at least one method for it to run.');
 
   this.env.runLoop.once('end', function () {
     this.emit('end');
@@ -433,7 +434,7 @@ Base.prototype.run = function run(cb) {
     });
   }
 
-  methods.filter(methodIsValid).forEach(addInQueue);
+  validMethods.forEach(addInQueue);
 
   var writeFiles = function () {
     this.env.runLoop.add('conflicts', this._writeFiles.bind(this), {

--- a/test/base.js
+++ b/test/base.js
@@ -308,6 +308,27 @@ describe('generators.Base', function () {
       assert.throws(gen.run.bind(gen));
     });
 
+    it('will run non-enumerable methods', function (done) {
+      var Generator = function () {
+        generators.Base.apply(this, arguments);
+      };
+      Generator.prototype = Object.create(generators.Base.prototype);
+      Object.defineProperty(Generator.prototype, 'nonenumerable', {
+        value: sinon.spy(),
+        configurable: true,
+        writable: true
+      });
+      var gen = new Generator([], {
+        resolved: 'dummy',
+        namespace: 'dummy',
+        env: this.env
+      });
+      gen.run(function () {
+        assert(gen.nonenumerable.called);
+        done();
+      });
+    });
+
     it('ignore underscore prefixed method', function (done) {
       this.testGen.run(function () {
         assert(this.TestGenerator.prototype._private.notCalled);


### PR DESCRIPTION
This adds the possibility of writing generators with ES2015 class
syntax. Fixes #767.