### PR TITLE
Fix deprecate bug

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -194,7 +194,7 @@ Base.prototype.spawnCommand = require('./actions/spawn_command');
 // DEPRECATED: Use the module directly
 Base.prototype.welcome = deprecate(
   'Generator#welcome() is deprecated. Instead, `require("yeoman-welcome")` directly.',
-  require('yeoman-welcome')
+  function () { console.log(require('yeoman-welcome')); }
 );
 
 /**


### PR DESCRIPTION
When I call `this.welcome()` in my generator's `initializing` function, always get a TypeError: Object has no method 'apply'.

And I found the bug in `util/deprecate.js` file, `deprecate.object` always call `deprecate` function without provide a function parameter.