### PR TITLE
Fix falsy answers not stored

### DIFF
--- a/lib/util/prompt-suggestion.js
+++ b/lib/util/prompt-suggestion.js
@@ -80,7 +80,7 @@ var storeListAnswer = function (question, answer) {
  */
 var storeAnswer = function (question, answer) {
   // Check if answer is not equal to default value or is undefined
-  if (answer && question.default !== answer) {
+  if (answer !== undefined && question.default !== answer) {
     return true;
   }
 

--- a/test/prompt-suggestion.js
+++ b/test/prompt-suggestion.js
@@ -292,5 +292,21 @@ describe('PromptSuggestion', function () {
       promptSuggestion.storeAnswers(this.store, question, mockAnswers);
       assert.equal(this.store.get('promptValues').respuesta, 'baz');
     });
+
+    it('store falsy answer (but not undefined) in global store', function () {
+      var question = {
+        name: 'respuesta',
+        default: true,
+        store: true
+      };
+
+      var mockAnswers = {
+        respuesta: false
+      };
+
+      promptSuggestion.prefillQuestions(this.store, question);
+      promptSuggestion.storeAnswers(this.store, question, mockAnswers);
+      assert.equal(this.store.get('promptValues').respuesta, false);
+    });
   });
 });


### PR DESCRIPTION
When answering to a question with a falsy value (like `false` or `0`), it wasn't store in the global yo json.