### PR TITLE
Fix Option Types

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -330,21 +330,30 @@ Base.prototype.argument = function argument(name, config) {
 };
 
 Base.prototype.parseOptions = function () {
+  var self = this;
+
   var opts = {};
   var shortOpts = {};
+  var passedOpts = [];
 
-  _.each(this._options, function (option) {
+  _.each(self._options, function(option) {
     opts[option.name] = option.type;
+    var shouldAppendEqual = (typeof self.options[option.name] !== 'boolean');
+    var aPassedOpt = '--' + option.name;
+    if (shouldAppendEqual) {
+      aPassedOpt += '=' + self.options[option.name];
+    }
+    passedOpts.push(aPassedOpt);
     if (option.alias) {
       shortOpts[option.alias] = '--' + option.name;
     }
   });
 
-  opts = nopt(opts, shortOpts, this._args, 0);
-  _.extend(this.options, opts);
+  opts = nopt(opts, shortOpts, passedOpts, 0);
+  _.extend(self.options, opts);
 
-  this.args = this.arguments = opts.argv.remain;
-  this.checkRequiredArgs();
+  self.args = self.arguments = opts.argv.remain;
+  self.checkRequiredArgs();
 };
 
 Base.prototype.checkRequiredArgs = function () {


### PR DESCRIPTION
Previously yeoman options were all treated by nopt as unknown,
meaning types were figured out via the value passed in.  This
effectively ignored any declared type.  This commit properly
passes the options into nopt, fixing the issue.