### PR TITLE
Remove state of skipped files to prevent repeated conflict checks

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -784,6 +784,11 @@ Base.prototype._writeFiles = function (done) {
   var conflictChecker = through.obj(function (file, enc, cb) {
     var stream = this;
 
+    // If the file state has been removed, move on
+    if (file.state === null) {
+      return cb();
+    }
+
     // Config file should not be processed by the conflicter. Just pass through
     var filename = path.basename(file.path);
 
@@ -800,6 +805,8 @@ Base.prototype._writeFiles = function (done) {
 
       if (status !== 'skip') {
         stream.push(file);
+      } else {
+        delete file.state;
       }
 
       cb();

--- a/test/base.js
+++ b/test/base.js
@@ -439,6 +439,30 @@ describe('generators.Base', function () {
       }.bind(this));
     });
 
+    it('does not prompt again for skipped files', function (done) {
+      var action = { action: 'skip' };
+      var filepath = path.join(__dirname, '/fixtures/conflict.js');
+      assert(pathExists.sync(filepath));
+
+      this.TestGenerator.prototype.writing = function () {
+        this.fs.write(filepath, 'some new content');
+      };
+
+      var env = yeoman.createEnv([], { 'skip-install': true }, new TestAdapter(action));
+      var testGen = new this.TestGenerator([], {
+        resolved: 'generator/app/index.js',
+        namespace: 'dummy',
+        env: env
+      });
+
+      var writeSpy = sinon.spy(testGen, '_writeFiles');
+
+      testGen.run(function () {
+        assert(writeSpy.calledOnce);
+        done();
+      }.bind(this));
+    });
+
     it('does not pass config file to conflicter', function (done) {
       this.TestGenerator.prototype.writing = function () {
         fs.writeFileSync(this.destinationPath('.yo-rc.json'), '{"foo": 3}');


### PR DESCRIPTION
The purpose of this is to prevent being prompted multiple times to overwrite files. It is related to #835 
