### PR TITLE
Fix typo in JSDoc example

### DIFF
--- a/lib/test/helpers.js
+++ b/lib/test/helpers.js
@@ -72,7 +72,7 @@ exports.gruntfile = function (options, done) {
  * @example
  * testDirectory(path.join(__dirname, './temp'), function () {
  *   fs.writeFileSync('testfile', 'Roses are red.');
- * );
+ * });
  */
 
 exports.testDirectory = function (dir, cb) {


### PR DESCRIPTION
That's it :octocat: 