### PR TITLE
pkg: fix main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "index.js",
     "lib"
   ],
-  "main": "lib/index.js",
   "keywords": [
     "development",
     "dev",


### PR DESCRIPTION
entry `index.js` point seems to be missing in `lib`, but it exists in the root, so this change fixes it