### PR TITLE
Remove non-existent file from JSDoc config

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,6 +1,6 @@
 {
   "source": {
-    "include": ["readme.md", "index.js", "lib"],
+    "include": ["readme.md", "lib"],
     "includePattern": ".+\\.js(doc)?$"
   },
   "opts": {


### PR DESCRIPTION
There is no index.js in the repo root anymore.