### PR TITLE
Fix the error thrown from generator is swallowed

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,7 +37,7 @@ gulp.task('test', ['pre-test'], function (cb) {
 
   gulp.src('test/*.js')
     .pipe(plumber())
-    .pipe(mocha({reporter: 'spec'}))
+    .pipe(mocha({reporter: 'spec', timeout: 3000}))
     .on('error', function (err) {
       mochaErr = err;
     })

--- a/lib/base.js
+++ b/lib/base.js
@@ -435,10 +435,14 @@ Base.prototype.run = function run(cb) {
 
           return method.apply(self, self.args);
         },
+        // runAsync return a promise which wraps first function.
+        // So ensure the callback function never throw an error.
         function (err) {
           if (err) {
             debug('An error occured while running ' + methodName, err);
-            self.emit('error', err);
+            if (self.listeners('error').length > 0) {
+              self.emit('error', err);
+            }
             cb(err);
             return;
           }

--- a/test/base.js
+++ b/test/base.js
@@ -324,6 +324,22 @@ describe('generators.Base', function () {
       });
     });
 
+    it('stop queue processing once an error is thrown and "error" event has no listeners', function (done) {
+      var error = new Error();
+      var spy = sinon.spy();
+
+      this.TestGenerator.prototype.throwing = function () {
+        throw error;
+      };
+      this.TestGenerator.prototype.afterError = spy;
+
+      this.testGen.run(function (err) {
+        assert.equal(err, error);
+        sinon.assert.notCalled(spy);
+        done();
+      });
+    });
+
     it('handle function returning promises as asynchronous', function (done) {
       var spy1 = sinon.spy();
       var spy2 = sinon.spy();


### PR DESCRIPTION
- Ensure the callback in runAsync never throw error.
- The unit test action#bulkDirectory() sometimes fail because of mocha timeout. So I set it to 3000ms.

Refer to #921