### PR TITLE
Base#prompt backwards compatibility

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -223,15 +223,20 @@ Base.prototype.welcome = deprecate(
  * user's answers as defaults.
  *
  * @param  {array} questions  Array of question descriptor objects. See {@link https://github.com/SBoudrias/Inquirer.js/blob/master/README.md Documentation}
+ * @param  {Function} [callback]  Receive a question object
  * @return {Promise}
  */
 
-Base.prototype.prompt = function (questions) {
+Base.prototype.prompt = function (questions, callback) {
   questions = promptSuggestion.prefillQuestions(this._globalConfig, questions);
 
   return this.env.adapter.prompt(questions).then(function (answers) {
     if (!this.options['skip-cache']) {
       promptSuggestion.storeAnswers(this._globalConfig, questions, answers);
+    }
+
+    if (_.isFunction(callback)) {
+      callback(answers);
     }
 
     return answers;


### PR DESCRIPTION
I really don't understand why this wasn't done in the first place, but alas. Hopefully this stops all the unexpected generator failures I've been seeing.

Now it works both ways (promise/callback).