### PR TITLE
npm cache by default

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 var dargs = require('dargs');
 var async = require('async');
 var chalk = require('chalk');
+var debug = require('debug')('generator:actions:install');
 
 /**
  * @mixin
@@ -33,6 +34,7 @@ install.runInstall = function (installer, paths, options, cb) {
   paths = Array.isArray(paths) ? paths : paths && paths.split(' ') || [];
 
   var args = ['install'].concat(paths).concat(dargs(options));
+  debug('Args', args);
 
   // Return early if we're skipping installation.
   if (this.options.skipInstall) {

--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -4,7 +4,6 @@ var _ = require('lodash');
 var dargs = require('dargs');
 var async = require('async');
 var chalk = require('chalk');
-var debug = require('debug')('generator:actions:install');
 
 /**
  * @mixin
@@ -34,7 +33,7 @@ install.runInstall = function (installer, paths, options, cb) {
   paths = Array.isArray(paths) ? paths : paths && paths.split(' ') || [];
 
   var args = ['install'].concat(paths).concat(dargs(options));
-  debug('Args', args);
+  args = args.concat(['--cache-min', 'Infinity']);
 
   // Return early if we're skipping installation.
   if (this.options.skipInstall) {

--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -33,7 +33,11 @@ install.runInstall = function (installer, paths, options, cb) {
   paths = Array.isArray(paths) ? paths : paths && paths.split(' ') || [];
 
   var args = ['install'].concat(paths).concat(dargs(options));
-  args = args.concat(['--cache-min', 'Infinity']);
+
+  // only for npm, use a minimum cache of one day
+  if (installer === 'npm') {
+    args = args.concat(['--cache-min', 24 * 60 * 60]);
+  }
 
   // Return early if we're skipping installation.
   if (this.options.skipInstall) {

--- a/test/base.js
+++ b/test/base.js
@@ -14,6 +14,8 @@ var Promise = require('pinkie-promise');
 var yeoman = require('yeoman-environment');
 var userHome = require('user-home');
 
+var LF = process.platform === 'win32' ? '\r\n' : '\n';
+
 mockery.enable({
   warnOnReplace: false,
   warnOnUnregistered: false
@@ -499,7 +501,7 @@ describe('generators.Base', function () {
       });
 
       testGen.run(function () {
-        assert.equal(fs.readFileSync(filepath, 'utf8'), 'var a = 1;\n');
+        assert.equal(fs.readFileSync(filepath, 'utf8'), 'var a = 1;' + LF);
         done();
       });
     });

--- a/test/base.js
+++ b/test/base.js
@@ -14,7 +14,7 @@ var Promise = require('pinkie-promise');
 var yeoman = require('yeoman-environment');
 var userHome = require('user-home');
 
-var LF = process.platform === 'win32' ? '\r\n' : '\n';
+var LF = require('os').EOL;
 
 mockery.enable({
   warnOnReplace: false,

--- a/test/install.js
+++ b/test/install.js
@@ -44,7 +44,7 @@ describe('generators.Base (actions/install mixin)', function () {
         sinon.assert.calledWithExactly(
           this.spawnCommandStub,
           'nestedScript',
-          ['install', 'path1', 'path2', '--cache-min', 'Infinity'],
+          ['install', 'path1', 'path2'],
           spawnEnv
         );
 
@@ -114,7 +114,7 @@ describe('generators.Base (actions/install mixin)', function () {
       this.dummy.npmInstall();
       this.dummy.run(function () {
         sinon.assert.calledOnce(this.spawnCommandStub);
-        sinon.assert.calledWithExactly(this.spawnCommandStub, 'npm', ['install'], {});
+        sinon.assert.calledWithExactly(this.spawnCommandStub, 'npm', ['install', '--cache-min', 86400], {});
         done();
       }.bind(this));
     });
@@ -141,7 +141,7 @@ describe('generators.Base (actions/install mixin)', function () {
       this.dummy.installDependencies(function () {
         sinon.assert.calledTwice(this.spawnCommandStub);
         sinon.assert.calledWithExactly(this.spawnCommandStub, 'bower', ['install'], {});
-        sinon.assert.calledWithExactly(this.spawnCommandStub, 'npm', ['install'], {});
+        sinon.assert.calledWithExactly(this.spawnCommandStub, 'npm', ['install', '--cache-min', 86400], {});
         done();
       }.bind(this));
       this.dummy.run();

--- a/test/install.js
+++ b/test/install.js
@@ -38,13 +38,13 @@ describe('generators.Base (actions/install mixin)', function () {
         }
       };
 
-      //args: installer, paths, options, cb
+      // args: installer, paths, options, cb
       this.dummy.runInstall('nestedScript', ['path1', 'path2'], spawnEnv, callbackSpy);
       this.dummy.run(function () {
         sinon.assert.calledWithExactly(
           this.spawnCommandStub,
           'nestedScript',
-          ['install', 'path1', 'path2'],
+          ['install', 'path1', 'path2', '--cache-min', 'Infinity'],
           spawnEnv
         );
 


### PR DESCRIPTION
Hi,

I worked with @hemanth on a little PR to add a default cache, very long (Infinite) by default.

This has the benefit of drastically speeding up npm installs, anytime a given package@version has already been installed.

It would work the same on the first run, and feel very fast on subsequent runs.

Also adding a little patch to have tests pass on win32 platform (LF issue)

cc @addyosmani 
