### PR TITLE
Chain install commands with double ampersand

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -124,7 +124,7 @@ install.installDependencies = function (options) {
     var tplValues = _.extend({
       skipInstall: false
     }, this.options, {
-      commands: chalk.yellow.bold(msg.commands.join(' & '))
+      commands: chalk.yellow.bold(msg.commands.join(' && '))
     });
     this.log(msg.template(tplValues));
   }


### PR DESCRIPTION
This PR chains together multiple install commands (e.g., `bower install && npm install`) with a double ampersand instead of a single ampersand. See issue https://github.com/yeoman/generator/issues/943 for more context around this.