### PR TITLE
Usage of stub consumes part of test reporter output

### DIFF
--- a/test/deprecate.js
+++ b/test/deprecate.js
@@ -7,7 +7,7 @@ var deprecate = require('../lib/util/deprecate');
 
 describe('deprecate()', function () {
   beforeEach(function () {
-    sinon.stub(console, 'log');
+    sinon.spy(console, 'log');
   });
 
   afterEach(function () {


### PR DESCRIPTION
Usage of stub for console.log affects the output of test reporter (it is not restored before the reporter logs the result of the test). Look at the deprecate test-suite. It's output is
```
  deprecate()
    .object()
    .property()
```
For example, you cannot see that there is `log a message` test that passed.