### PR TITLE
Fix error handling for non installed install methods

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -43,15 +43,14 @@ install.runInstall = function (installer, paths, options, cb) {
   this.env.runLoop.add('install', function (done) {
     this.emit(installer + 'Install', paths);
     this.spawnCommand(installer, args, options)
-      .on('error', cb)
+      .on('error', function (err){
+        console.log(chalk.red('Could not finish installation. \n') +
+          'Please install ' + installer + ' with ' +
+          chalk.yellow('npm install -g ' + installer) + ' and try again.'
+        );
+        cb(err);
+      })
       .on('exit', function (err) {
-        if (err === 127) {
-          this.log.error(
-            'Could not find ' + installer + '. Please install with ' +
-            '`npm install -g ' + installer + '`.'
-          );
-        }
-
         this.emit(installer + 'Install:end', paths);
         cb(err);
         done();


### PR DESCRIPTION
Closes #871

# Setup

A `bower.json` and a `package.json` without any dependencies defined.

## Test case 1

Using the following install method within a dummy generator:

```js
install: function () {
  this.npmInstall(['lodash'], { save: true });
  this.bowerInstall('lodash', { save: true });
}
```

### Behavior before:

`bower install` fails silently by generating the following output:

![silent-fail](https://cloud.githubusercontent.com/assets/441011/19456678/d9f87f8c-94c2-11e6-9f67-f8dbb438be62.png)

### Behavior after:

`bower install` fails properly with the following error message:

<img width="777" alt="proper-error" src="https://cloud.githubusercontent.com/assets/441011/19456695/e43f2d56-94c2-11e6-9443-72b24e86450d.png">

## Test case 2

Using callbacks for installation within a dummy generator:

```js
install: function () {
  this.npmInstall(['lodash'], { save: true }, function (callbackParam) {
    console.log('npm callbackParam=', callbackParam);
  });

  this.bowerInstall('lodash', { save: true }, function (callbackParam) {
    console.log('bower callbackParam=', callbackParam);
  });
}
```

### Behavior before:

`bower install` fails with printing the raw error:

<img width="761" alt="fail-with-callback" src="https://cloud.githubusercontent.com/assets/441011/19456709/fb51be28-94c2-11e6-9265-c9e9b34e0955.png">

### Behavior after:

`bower install` fails with printing a proper error message and the raw error:

<img width="777" alt="proper-error-with-callback" src="https://cloud.githubusercontent.com/assets/441011/19456727/106e4c86-94c3-11e6-9a26-adbd56d81ac9.png">

---

Tested with node `5.5.0` and `6.7.0`

