### PR TITLE
Fix deprecation message for using `NamedBase`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,6 +89,11 @@ yeoman.generators = {
 };
 deprecate.property(
   'require(\'yeoman-generator\').generators.Base is deprecated. Use require(\'yeoman-generator\').Base directly',
-  yeoman,
-  'generators'
+  yeoman.generators,
+  'Base'
+);
+deprecate.property(
+  'NamedBase constructor is deprecated. See https://github.com/yeoman/generator/issues/882',
+  yeoman.generators,
+  'NamedBase'
 );


### PR DESCRIPTION
Fixes #886

Changes deprecation message when using 

```
yeoman.generators.NamedBase.extend()
```

**Before:**

<img width="937" alt="yeoman generators namedbase extend-before" src="https://cloud.githubusercontent.com/assets/441011/19496678/dbdbe7be-9588-11e6-9d1c-cf8dddd0db93.png">

**After:**

<img width="937" alt="yeoman generators namedbase extend-after" src="https://cloud.githubusercontent.com/assets/441011/19496683/e3d2f566-9588-11e6-9e3f-aa5f422b9802.png">

---

Correct deprecation messages remain untouched.

```
yeoman.generators.Base.extend()
```

<img width="937" alt="yeoman generators base extend-after" src="https://cloud.githubusercontent.com/assets/441011/19496695/f5502944-9588-11e6-9bad-cbccda5e1f2d.png">


```
yeoman.NamedBase.extend()
```

<img width="937" alt="yeoman namedbase extend-after" src="https://cloud.githubusercontent.com/assets/441011/19496706/06158d5a-9589-11e6-9171-7375d910aec4.png">