### PR TITLE
Remove duplicated reference of the readme for docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "test": "gulp",
-    "doc": "jsdoc -c jsdoc.json readme.md",
+    "doc": "jsdoc -c jsdoc.json",
     "prepublish": "gulp prepublish"
   },
   "dependencies": {


### PR DESCRIPTION
It’s already set up to use the readme for JSDoc HTML file over here:
https://github.com/yeoman/generator/blob/master/jsdoc.json#L3

Works fine without that duplicate in package.json 😘 