### PR TITLE
Setup Travis deployment of generated docs to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,28 @@ node_js:
   - v4
   - v5
   - v6
+after_success: ./deploy.sh
+env:
+  global:
+  - COMMIT_AUTHOR_EMAIL: "yeoman@yeoman.io"
+  - COMMIT_AUTHOR_NAME: "yeoman"
+  - SOURCE_BRANCH: "master"
+  - TARGET_BRANCH: "gh-pages"
+  - DOCS_DIR: "../yeoman-generator-doc"
+  # GH_OAUTH_TOKEN is the oauth token generated as described at
+  # https://help.github.com/articles/creating-an-oauth-token-for-command-line-use
+  #
+  # `curl -u 'githubUserName' -d '{"scopes":["repo"],"note":"push to gh-pages from travis"}' https://api.github.com/authorizations`
+  #
+  # It returns a OAuth token which must be encrypted using the travis CLI:
+  # https://github.com/travis-ci/travis.rb#installation
+  #
+  # (Users with two-factor authentication enabled should set up an OAuth token
+  # through the web UI: https://github.com/settings/tokens)
+  #
+  # `travis encrypt GH_OAUTH_TOKEN=XXXXXXXXXXXXXXX`
+  #
+  # It returns encrypted key you must assign to the `secure` property below
+  - secure: encryptedOAuthToken
+  - GH_OWNER: yeoman
+  - GH_PROJECT_NAME: generator

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Exit with nonzero exit code if anything fails
+set -e
+
+REPO=`git config remote.origin.url`
+SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
+SHA=`git rev-parse --verify HEAD`
+
+# Pull Only build and deploy docs when the current build is for a Git tag.
+if [[ $TRAVIS_TAG == "" ]]; then
+    echo "Not a build for a Git tag. Skipping generating and deploying the docs."
+    exit 0
+fi
+
+# Create $DOCS_DIR
+mkdir $DOCS_DIR
+echo -e "Created directory $DOCS_DIR\n"
+
+# Change directory to $DOCS_DIR
+cd $DOCS_DIR
+echo "Changed directory to: "
+pwd
+echo -e ""
+
+# Clean out existing contents
+rm -rf **
+echo -e "Cleaned out existing contents of $DOCS_DIR\n"
+
+# Clone the existing gh-pages into $DOCS_DIR
+git clone $REPO .
+echo -e "Cloned $REPO\n"
+git checkout $TARGET_BRANCH
+
+# Generate docs in $TRAVIS_BUILD_DIR
+cd $TRAVIS_BUILD_DIR
+npm run doc
+echo -e "Generated docs\n"
+
+# Change directory to $DOCS_DIR
+cd $DOCS_DIR
+
+# Git setup
+git config user.name $COMMIT_AUTHOR_NAME
+git config user.email $COMMIT_AUTHOR_EMAIL
+
+# Commit the new of the new version
+git add .
+git commit -m "Deploy docs to GitHub Pages ($TRAVIS_TAG)"
+echo -e "Comitted docs to $TARGET_BRANCH\n"
+
+# Now that we're all set up, we can push.
+# Info: Any command that using GH_OAUTH_TOKEN must pipe the output to /dev/null
+# to not expose your oauth token
+git push https://${GH_OAUTH_TOKEN}@github.com/${GH_OWNER}/${GH_PROJECT_NAME} HEAD:$TARGET_BRANCH > /dev/null 2>&1
+echo -e "Pushed changes to $TARGET_BRANCH\n"
+echo "We are done ✌(-‿-)✌"


### PR DESCRIPTION
Closes #673
Closes yeoman/Hackathons#9

This generates and deploys docs with every published tag to the `gh-pages` branch 🎉 

This PR is an adoption of a working proof of concept which is a sharable solution composed of:

+ a few additions to the existing travis config
+ a bash script

See https://github.com/mischah/test-auto-publishing-gh-pages

Its easy adaptable to fix yeoman/environment#9 as well (just by changing a few values in `.travis.yml`).

But to get that running over here someone with push access to this repo has to enable push access for Travis by:

1. creating a Github OAuth token
2. encrypting that OAuth token for use with Travis

These steps are described within the comments of the updated `.travis.yml`:
https://github.com/mischah/generator/blob/automate-publishing-docs/.travis.yml#L17-L30

--- 

One last thing:
Im executing the deployment script within the `after_success` phase of the Travis build process for now. 

This means it [won’t break the build](https://docs.travis-ci.com/user/customizing-the-build/#Breaking-the-Build) in case of an error with deployment.
Is this an expected behavior?

Pros:
+ It won’t break a build which has green test and zero linting errors

Cons:
+ We won’t notice when there are problems with generating/deploying the docs

Any thoughts on that?