### PR TITLE
Prevent multiple commits of docs in gh-pages branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - SOURCE_BRANCH: master
   - TARGET_BRANCH: gh-pages
   - DOCS_DIR: "../yeoman-generator-doc"
-  - secure: encryptedOAuthToken
   - GH_OWNER: yeoman
   - GH_PROJECT_NAME: generator
+  - PACKAGE_NAME: yeoman-generator
   - secure: Hv7gACQoYGtesz1NTJYRHjGCimEJEjj4bQP2iTpDUUbfAiYe/4QPemoyDEFjRxbu5m2uoYwMk0AQrW7DnQhNAhl7u24jYnRgQyd/2GOx3xZgjwnao27gsrTHss4IyXEaS2h3kRuIVSD+xibz/lwZm+erHOQ9VOwvCQkOKnILXW8=

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,14 +23,14 @@ echo "Changed directory to: "
 pwd
 echo -e ""
 
-# Clean out existing contents
-rm -rf **
-echo -e "Cleaned out existing contents of $DOCS_DIR\n"
-
 # Clone the existing gh-pages into $DOCS_DIR
 git clone $REPO .
 echo -e "Cloned $REPO\n"
 git checkout $TARGET_BRANCH
+
+# Clean out existing contents
+rm -rf **
+echo -e "Cleaned out existing contents of $DOCS_DIR\n"
 
 # Generate docs in $TRAVIS_BUILD_DIR
 cd $TRAVIS_BUILD_DIR
@@ -40,12 +40,22 @@ echo -e "Generated docs\n"
 # Change directory to $DOCS_DIR
 cd $DOCS_DIR
 
+# Flatten content of $DOCS_DIR
+mv $PACKAGE_NAME/**/** ./
+rm -rf $PACKAGE_NAME
+
 # Git setup
 git config user.name $COMMIT_AUTHOR_NAME
 git config user.email $COMMIT_AUTHOR_EMAIL
 
+# Exit if there are no changes to the generated content
+if [ -z "$(git status --porcelain)" ]; then
+    echo "No changes to the output on this run; exiting."
+    exit 0
+fi
+
 # Commit the new of the new version
-git add .
+git add --all .
 git commit -m "Deploy docs to GitHub Pages ($TRAVIS_TAG)"
 echo -e "Comitted docs to $TARGET_BRANCH\n"
 

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -5,7 +5,13 @@
   },
   "opts": {
     "recurse": true,
-    "destination": "../yeoman-generator-doc/"
+    "destination": "../yeoman-generator-doc/",
+    "package": "package.json"
+  },
+  "templates": {
+    "default": {
+      "includeDate": false
+    }
   },
   "plugins": [
     "plugins/markdown"


### PR DESCRIPTION
Post treatment of #971

The changes of this PR will prevent multiple commits of docs in gh-pages branch when pushing a new tag.

It could be easier. But Travis doesn’t offer something like a [single `after_success` callback after *all* builds](https://github.com/travis-ci/travis-ci/issues/929).

So I first checked if there are changes between commits: 
https://github.com/yeoman/generator/commit/f7df1d7daf064a2ae048c437d38a091c76dc8a05#diff-60254338249f657a0a83f98258a56bfeR51

Sadly this approach alone didn’t worked out. Because the default JSDoc template renders a timestamp into the footer.
See: https://github.com/yeoman/generator/commit/1475d16fc4fa34bd1334ae3764c67788c6a56e05

So I disabled the output of the date/time in the footer and configured JSDoc to render the package name and version number from the `package.json` to the homepage of the docs.

I got it working in my test repo over here.
