### PR TITLE
Only build and deploy docs on a specific node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ env:
   - DOCS_DIR: "../yeoman-generator-doc"
   - GH_OWNER: yeoman
   - GH_PROJECT_NAME: generator
-  - PACKAGE_NAME: yeoman-generator
+  - DEPLOY_ON_NODE_VERSION: v6
   - secure: Hv7gACQoYGtesz1NTJYRHjGCimEJEjj4bQP2iTpDUUbfAiYe/4QPemoyDEFjRxbu5m2uoYwMk0AQrW7DnQhNAhl7u24jYnRgQyd/2GOx3xZgjwnao27gsrTHss4IyXEaS2h3kRuIVSD+xibz/lwZm+erHOQ9VOwvCQkOKnILXW8=

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,14 +29,14 @@ echo "Changed directory to: "
 pwd
 echo -e ""
 
-# Clean out existing contents
-rm -rf **
-echo -e "Cleaned out existing contents of $DOCS_DIR\n"
-
 # Clone the existing gh-pages into $DOCS_DIR
 git clone $REPO .
 echo -e "Cloned $REPO\n"
 git checkout $TARGET_BRANCH
+
+# Clean out existing contents
+rm -rf **
+echo -e "Cleaned out existing contents of $DOCS_DIR\n"
 
 # Generate docs in $TRAVIS_BUILD_DIR
 cd $TRAVIS_BUILD_DIR
@@ -45,6 +45,12 @@ echo -e "Generated docs\n"
 
 # Change directory to $DOCS_DIR
 cd $DOCS_DIR
+
+# Exit if there are no changes to the generated content
+if [ -z "$(git status --porcelain)" ]; then
+    echo "No changes to the output on this run; exiting."
+    exit 0
+fi
 
 # Git setup
 git config user.name $COMMIT_AUTHOR_NAME

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -5,13 +5,7 @@
   },
   "opts": {
     "recurse": true,
-    "destination": "../yeoman-generator-doc/",
-    "package": "package.json"
-  },
-  "templates": {
-    "default": {
-      "includeDate": false
-    }
+    "destination": "../yeoman-generator-doc"
   },
   "plugins": [
     "plugins/markdown"


### PR DESCRIPTION
Simplified the prevention of multiple commits of docs in `gh-pages` branch as discussed in #975 

