### PR TITLE
Switch JSDoc template

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -5,7 +5,17 @@
   },
   "opts": {
     "recurse": true,
-    "destination": "../yeoman-generator-doc"
+    "destination": "../yeoman-generator-doc",
+    "template": "node_modules/tui-jsdoc-template"
+  },
+  "templates": {
+    "logo": {
+        "url": "https://cloud.githubusercontent.com/assets/441011/20215255/4c2a7246-a813-11e6-826e-80a78b30e9e5.png",
+        "width": "127px",
+        "height": "14px"
+    },
+    "name": "Generator",
+    "footerText": "BSD license Copyright (c) Google"
   },
   "plugins": [
     "plugins/markdown"

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "nock": "^8.0.0",
     "pinkie-promise": "^2.0.0",
     "proxyquire": "^1.0.0",
-    "sinon": "^1.9.1"
+    "sinon": "^1.9.1",
+    "tui-jsdoc-template": "^1.0.4"
   }
 }


### PR DESCRIPTION
So we have a search in the API docs as requested in yeoman/yeoman#1485

Let me quote myself from yeoman/yeoman#1485:

> I did some research regarding JSDoc templates and tried a few.
> That made me sad. There are just 3 with search functionality. And just one of them makes sense to use for the Yeoman docs because it’s looks good, has a good UX and offers all the features of the default template.
>
> The good news: The one is a extremely new kid on the block (first release 4 days ago) but its super awesome.

The docs will look like this:
![image](https://cloud.githubusercontent.com/assets/441011/20215563/5b367c92-a815-11e6-88dc-a6283676cbb7.png)
![image](https://cloud.githubusercontent.com/assets/441011/20215585/7b3d7982-a815-11e6-9ea5-a29d5073c09e.png)
