### PR TITLE
Add version number to generated docs

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -6,7 +6,8 @@
   "opts": {
     "recurse": true,
     "destination": "../yeoman-generator-doc",
-    "template": "node_modules/tui-jsdoc-template"
+    "template": "node_modules/tui-jsdoc-template",
+    "package": "package.json"
   },
   "templates": {
     "logo": {


### PR DESCRIPTION
Takes the version number from `package.json` and prints it to the left column of the docs.

![image](https://cloud.githubusercontent.com/assets/441011/20234132/d7d5c318-a877-11e6-8bb7-cdabfb32296b.png)
