### PR TITLE
Expose the directory where the generator is being executed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,6 +115,8 @@ var Base = module.exports = function Base(args, options) {
   this.log = this.env.adapter.log;
 
   // determine the app root
+  this.contextRoot = this.env.cwd;
+
   var rootPath = findUp.sync('.yo-rc.json', {
     cwd: this.env.cwd
   });

--- a/test/base.js
+++ b/test/base.js
@@ -53,7 +53,8 @@ describe('Base', function () {
   describe('constructor', function () {
     it('set the CWD where `.yo-rc.json` is found', function () {
       var projectDir = path.join(__dirname, 'fixtures/dummy-project');
-      process.chdir(path.join(projectDir, 'subdir'));
+      var subdir = path.join(projectDir, 'subdir');
+      process.chdir(subdir);
       this.env.cwd = process.cwd();
 
       var dummy = new this.Dummy(['foo'], {
@@ -63,6 +64,7 @@ describe('Base', function () {
 
       assert.equal(process.cwd(), projectDir);
       assert.equal(dummy.destinationPath(), projectDir);
+      assert.equal(dummy.contextRoot, subdir);
     });
 
     it('use the environment options', function () {


### PR DESCRIPTION
This PR propose an elegant solution to issue #947.

By exposing the directory where the generator was executed, we give the opportunity to subgenerators to scaffold into the current folder instead of the project folder.

Tests have been implemented. I hope the name `contextRoot` for the property is OK to everyone.