### PR TITLE
Update example for docs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,12 +48,12 @@ var debug = require('debug')('yeoman:generator');
  * @property {Function} log         - Output content through Interface Adapter
  *
  * @example
- * var generator = require('yeoman-generator');
- * var MyGenerator = generator.Base.extend({
- *   writing: function() {
- *     this.fs.write('var foo = 1;', this.destinationPath('index.js'));
+ * const Generator = require('yeoman-generator');
+ * module.exports = class extends Generator {
+ *   writing() {
+ *     this.fs.write('const foo = 1;', this.destinationPath('index.js'));
  *   }
- * });
+ * };
  */
 
 var Base = module.exports = function Base(args, options) {


### PR DESCRIPTION
There was a `generator.Base.extend` in the docs.

Guess that should be ES6 too, right?