### PR TITLE
feat: add getArgument

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -133,6 +133,7 @@ class Generator extends EventEmitter {
     this.appname = this.determineAppname();
     this.config = this._getStorage();
     this._globalConfig = this._getGlobalStorage();
+    this.orginalArgs = _.clone(this);
 
     // Ensure source/destination path, can be configured from subclasses
     this.sourceRoot(path.join(path.dirname(this.resolved), 'templates'));
@@ -372,6 +373,18 @@ class Generator extends EventEmitter {
     const self = this;
     this._running = true;
     this.emit('run');
+
+    const restArgs = Object.keys(_.clone(this)).filter(orginalArg => {
+      return !this.orginalArgs[orginalArg] && this[orginalArg] &&
+        (orginalArg.substring(0, 1) !== '_') && (orginalArg !== 'orginalArgs');
+    });
+
+    this.env.getArgument = function (name) {
+      if (restArgs.includes(name)) {
+        const query = name.toString();
+        return self[query];
+      }
+    };
 
     const methods = Object.getOwnPropertyNames(Object.getPrototypeOf(this));
     const validMethods = methods.filter(methodIsValid);


### PR DESCRIPTION
Adds a `env.getArgument` function to env, as there's no way of getting an `this` object inside a generator. If you want to run a feature based on an internal object of the generator, this opens up the opportunity for that. 

I found no "real" effective way to get calls from the child class, so I've made a copy of the `this` object at initialization, where we later compare the initial state of the `this` object to the updated `this` after it has been initialized. This way we can get the added `this` objects from an generator. 

Examples:


# Generator 

```js
module.exports = class WebpackGenerator extends Generator {
	constructor(args, opts) {
		super(args, opts);
		this.configuration = {}
	}
	prompting() {
		return this.prompt([Input('entry','What is the name of the entry point in your application?'),
			Input('output','What is the name of the output directory in your application?')]).then( (h) => {
					this.configuration = h;
			});
	}
};
```

# Yeoman Env

```js
env.run('npm:app')
  .on('end', () => {
        const myArg = env.getArgument('configuration');
       // logs { entry: ..., output: ...} 
  });
```