### PR TITLE
Run dependencies before the generator that composed them

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -369,6 +369,9 @@ class Generator extends EventEmitter {
   run(cb) {
     cb = cb || (() => {});
 
+    // Dependencies run all their steps before we do.
+    _.invokeMap(this._composedWith, 'run');
+
     const self = this;
     this._running = true;
     this.emit('run');
@@ -456,7 +459,6 @@ class Generator extends EventEmitter {
       });
     });
 
-    _.invokeMap(this._composedWith, 'run');
     return this;
   }
 

--- a/test/base.js
+++ b/test/base.js
@@ -762,6 +762,17 @@ describe('Base', () => {
       }, 100);
     });
 
+    it('runs composed generator steps before the generator they are composed with', function (done) {
+      this.Dummy.prototype.writing = sinon.spy();
+      this.GenCompose.prototype.writing = sinon.spy();
+      this.dummy.composeWith('composed:gen');
+
+      this.dummy.run(() => {
+        assert(this.Dummy.prototype.writing.calledAfter(this.GenCompose.prototype.writing));
+        done();
+      });
+    });
+
     it('run the composed generator even if main generator is already running.', function (done) {
       this.Dummy.prototype.writing = function () {
         this.composeWith('composed:gen');


### PR DESCRIPTION
As a fix to https://github.com/yeoman/generator/issues/894#issuecomment-294388612

This seems to better match expectations; but people may be relying on the previous behavior?