### PR TITLE
Don't die on diffing file deletions (again)

### DIFF
--- a/lib/util/binary-diff.js
+++ b/lib/util/binary-diff.js
@@ -8,7 +8,8 @@ const Table = require('cli-table');
 
 exports.isBinary = (existingFilePath, newFileContents) => {
   const existingHeader = readChunk.sync(existingFilePath, 0, 512);
-  return istextorbinary.isBinarySync(undefined, existingHeader) || istextorbinary.isBinarySync(undefined, newFileContents);
+  return istextorbinary.isBinarySync(undefined, existingHeader) ||
+    (newFileContents && istextorbinary.isBinarySync(undefined, newFileContents));
 };
 
 exports.diff = (existingFilePath, newFileContents) => {
@@ -18,6 +19,10 @@ exports.diff = (existingFilePath, newFileContents) => {
   });
 
   let sizeDiff;
+
+  if (!newFileContents) {
+    newFileContents = Buffer.from([]);
+  }
 
   if (existingStat.size > newFileContents.length) {
     sizeDiff = '-';


### PR DESCRIPTION
Makes `null` content (file deletion):

1. not identify as binary (so default diff style is nicer)
2. not break binary diff if it is

Addresses regression(?) of #950