### PR TITLE
Set file permission to read/write only for creator on config file(s).

### DIFF
--- a/lib/util/storage.js
+++ b/lib/util/storage.js
@@ -1,5 +1,6 @@
 'use strict';
 const assert = require('assert');
+const nodeFs = require('fs');
 const _ = require('lodash');
 
 /**
@@ -45,9 +46,14 @@ class Storage {
    * @private
    */
   _persist(val) {
+    const self = this;
     const fullStore = this.fs.readJSON(this.path, {});
     fullStore[this.name] = val;
     this.fs.write(this.path, JSON.stringify(fullStore, null, '  '));
+    this.fs.store.on('change', () => {
+      // Try to fix user rights, otherwise silently fail
+      nodeFs.chmod(self.path, '600', () => {});
+    });
   }
 
   /**


### PR DESCRIPTION
When a Generator creates configuration files (`~/.yo-rc-global.json` and `./.yo-rc.json`), those should be readable & writable only by created user, aka setting a file permission `-rw-------` aka `chmod 600 ./yo-rc.json` on *nix systems.

If there are any errors while executing `fs.chmod()` function call, code simply ignores it with empty callback.