### PR TITLE
fix: Do not apply user defaults when question.choices is a function. Fixes #1051.

### DIFF
--- a/lib/util/prompt-suggestion.js
+++ b/lib/util/prompt-suggestion.js
@@ -115,7 +115,15 @@ promptSuggestion.prefillQuestions = (store, questions) => {
 
     const storedValue = promptValues[question.name];
 
-    if (storedValue === undefined) {
+    if (
+      (storedValue === undefined) ||
+      (
+        Object.prototype.hasOwnProperty.call(question, 'choices') &&
+        _.isFunction(question.choices)
+      )
+    ) {
+      // Do not override prompt default when question.choices is a function,
+      // since can't guarantee that the `storedValue` will even be in the returned choices
       return question;
     }
 

--- a/lib/util/prompt-suggestion.js
+++ b/lib/util/prompt-suggestion.js
@@ -115,13 +115,7 @@ promptSuggestion.prefillQuestions = (store, questions) => {
 
     const storedValue = promptValues[question.name];
 
-    if (
-      (storedValue === undefined) ||
-      (
-        Object.prototype.hasOwnProperty.call(question, 'choices') &&
-        _.isFunction(question.choices)
-      )
-    ) {
+    if ((storedValue === undefined) || _.isFunction(question.choices)) {
       // Do not override prompt default when question.choices is a function,
       // since can't guarantee that the `storedValue` will even be in the returned choices
       return question;

--- a/test/prompt-suggestion.js
+++ b/test/prompt-suggestion.js
@@ -179,14 +179,14 @@ describe('PromptSuggestion', () => {
       });
     });
 
-    describe.only('take a checkbox with choices from a function', () => {
+    describe('take a checkbox with choices from a function', () => {
       beforeEach(function () {
         this.store.set('promptValues', {
           respuesta: ['foo']
         });
       });
 
-      it('override default from an array with objects', function () {
+      it('does not override default from an array with objects', function () {
         const question = {
           type: 'checkbox',
           name: 'respuesta',
@@ -205,14 +205,10 @@ describe('PromptSuggestion', () => {
         };
         const result = promptSuggestion.prefillQuestions(this.store, question)[0];
 
-        result.choices.forEach(choice => {
-          assert.equal(choice.checked, false);
-        });
-
-        assert.deepEqual(result.default, ['foo']);
+        assert.deepEqual(result.default, ['bar']);
       });
 
-      it('override default from an array with strings', function () {
+      it('does not override default from an array with strings', function () {
         const question = {
           type: 'checkbox',
           name: 'respuesta',
@@ -221,10 +217,10 @@ describe('PromptSuggestion', () => {
           choices: () => ['foo', new inquirer.Separator('spacer'), 'bar', 'baz']
         };
         const result = promptSuggestion.prefillQuestions(this.store, question)[0];
-        assert.deepEqual(result.default, ['foo']);
+        assert.deepEqual(result.default, ['bar']);
       });
 
-      describe('with multiple defaults', () => {
+      describe('does not override even with multiple defaults', () => {
         beforeEach(function () {
           this.store.set('promptValues', {
             respuesta: ['foo', 'bar']
@@ -250,11 +246,7 @@ describe('PromptSuggestion', () => {
           };
           const result = promptSuggestion.prefillQuestions(this.store, question)[0];
 
-          result.choices.forEach(choice => {
-            assert.equal(choice.checked, false);
-          });
-
-          assert.deepEqual(result.default, ['foo', 'bar']);
+          assert.deepEqual(result.default, ['bar']);
         });
 
         it('from an array with strings', function () {
@@ -266,7 +258,7 @@ describe('PromptSuggestion', () => {
             choices: () => ['foo', new inquirer.Separator('spacer'), 'bar', 'baz']
           };
           const result = promptSuggestion.prefillQuestions(this.store, question)[0];
-          assert.deepEqual(result.default, ['foo', 'bar']);
+          assert.deepEqual(result.default, ['bar']);
         });
       });
     });

--- a/test/prompt-suggestion.js
+++ b/test/prompt-suggestion.js
@@ -179,6 +179,98 @@ describe('PromptSuggestion', () => {
       });
     });
 
+    describe.only('take a checkbox with choices from a function', () => {
+      beforeEach(function () {
+        this.store.set('promptValues', {
+          respuesta: ['foo']
+        });
+      });
+
+      it('override default from an array with objects', function () {
+        const question = {
+          type: 'checkbox',
+          name: 'respuesta',
+          default: ['bar'],
+          store: true,
+          choices: () => [{
+            value: 'foo',
+            name: 'foo'
+          }, new inquirer.Separator('spacer'), {
+            value: 'bar',
+            name: 'bar'
+          }, {
+            value: 'baz',
+            name: 'baz'
+          }]
+        };
+        const result = promptSuggestion.prefillQuestions(this.store, question)[0];
+
+        result.choices.forEach(choice => {
+          assert.equal(choice.checked, false);
+        });
+
+        assert.deepEqual(result.default, ['foo']);
+      });
+
+      it('override default from an array with strings', function () {
+        const question = {
+          type: 'checkbox',
+          name: 'respuesta',
+          default: ['bar'],
+          store: true,
+          choices: () => ['foo', new inquirer.Separator('spacer'), 'bar', 'baz']
+        };
+        const result = promptSuggestion.prefillQuestions(this.store, question)[0];
+        assert.deepEqual(result.default, ['foo']);
+      });
+
+      describe('with multiple defaults', () => {
+        beforeEach(function () {
+          this.store.set('promptValues', {
+            respuesta: ['foo', 'bar']
+          });
+        });
+
+        it('from an array with objects', function () {
+          const question = {
+            type: 'checkbox',
+            name: 'respuesta',
+            default: ['bar'],
+            store: true,
+            choices: () => [{
+              value: 'foo',
+              name: 'foo'
+            }, new inquirer.Separator('spacer'), {
+              value: 'bar',
+              name: 'bar'
+            }, {
+              value: 'baz',
+              name: 'baz'
+            }]
+          };
+          const result = promptSuggestion.prefillQuestions(this.store, question)[0];
+
+          result.choices.forEach(choice => {
+            assert.equal(choice.checked, false);
+          });
+
+          assert.deepEqual(result.default, ['foo', 'bar']);
+        });
+
+        it('from an array with strings', function () {
+          const question = {
+            type: 'checkbox',
+            name: 'respuesta',
+            default: ['bar'],
+            store: true,
+            choices: () => ['foo', new inquirer.Separator('spacer'), 'bar', 'baz']
+          };
+          const result = promptSuggestion.prefillQuestions(this.store, question)[0];
+          assert.deepEqual(result.default, ['foo', 'bar']);
+        });
+      });
+    });
+
     describe('take a rawlist / expand', () => {
       beforeEach(function () {
         this.store.set('promptValues', {


### PR DESCRIPTION
This is a bit odd as it introduces a difference in the way Yeoman handles applying storage defaults, however it appears to be the safest and least intrusive way to honor the Inquirer API.

In the future, we could consider pre-filling prompts on a question-by-question basis so that we can invoke the `question.choices` function with the previous answers.