### PR TITLE
Enable multiple methods for default queue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -415,23 +415,18 @@ class Generator extends EventEmitter {
       const queueName = self.env.runLoop.queueNames.indexOf(name) === -1 ? null : name;
 
       // Name points to a function; run it!
-      if (typeof item === 'function') {
+      if (_.isFunction(item)) {
         return addMethod(item, name, queueName);
+      } else if (_.isPlainObject(item) || _.isArray(item)) {
+        // Run each queue items
+        _.each(item, (method, methodName) => {
+          if (!_.isFunction(method) || !methodIsValid(methodName)) {
+            return;
+          }
+
+          addMethod(method, methodName, queueName);
+        });
       }
-
-      // Not a queue hash; stop
-      if (!queueName) {
-        return;
-      }
-
-      // Run each queue items
-      _.each(item, (method, methodName) => {
-        if (!_.isFunction(method) || !methodIsValid(methodName)) {
-          return;
-        }
-
-        addMethod(method, methodName, queueName);
-      });
     }
 
     validMethods.forEach(addInQueue);

--- a/test/base.js
+++ b/test/base.js
@@ -179,6 +179,10 @@ describe('Base', () => {
         exec: sinon.spy(),
         exec2: sinon.spy(),
         exec3: sinon.spy(),
+        exec4: {
+          exec41: sinon.spy(),
+          _private: sinon.spy()
+        },
         _private: sinon.spy(),
         prompting: {
           m1: sinon.spy(),
@@ -393,6 +397,20 @@ describe('Base', () => {
     it('ignore underscore prefixed method in a queue hash', function (done) {
       this.testGen.run(() => {
         assert(this.TestGenerator.prototype.prompting._private.notCalled);
+        done();
+      });
+    });
+
+    it('run methods which put into default queue', function (done) {
+      this.testGen.run(() => {
+        assert(this.TestGenerator.prototype.exec4.exec41.calledOnce);
+        done();
+      });
+    });
+
+    it('ignore underscore prefixed methods which put into default queue', function (done) {
+      this.testGen.run(() => {
+        assert(this.TestGenerator.prototype.exec4._private.notCalled);
         done();
       });
     });


### PR DESCRIPTION
Hey,

Base on example in documentation:
http://yeoman.io/authoring/running-context.html

> Priorities are defined in your code as special prototype method names. When a method name is the same as a priority name, the run loop pushes the method into this special queue. If the method name doesn't match a priority, it is pushed in the default group.

`
Generator.extend({
  priorityName: {
    method() {},
    method2() {}
  }
});
`


So each own prototype method have to be called in default queue.
But multiple methods works only for defined queues.

That's why added `multiple methods` feature to other methods to reach same behaviour.
