### PR TITLE
Change options and args order

### DIFF
--- a/lib/actions/help.js
+++ b/lib/actions/help.js
@@ -70,11 +70,11 @@ help.usage = function () {
   let args = '';
 
   if (this._arguments.length > 0) {
-    args = this._arguments.map(formatArg).join(' ');
+    args = this._arguments.map(formatArg).join(' ') + ' ';
   }
 
   name = name.replace(/^yeoman:/, '');
-  let out = `yo ${name} ${options} ${args}`;
+  let out = `yo ${name} ${args}${options}`;
 
   if (this.description) {
     out += '\n\n' + this.description;

--- a/test/base.js
+++ b/test/base.js
@@ -845,7 +845,7 @@ describe('Base', () => {
       const help = this.dummy.help();
       const expected = [
         'Usage:',
-        'yo dummy [options] [<baz>]',
+        'yo dummy [<baz>] [options]',
         '',
         'A new desc for this generator',
         '',
@@ -876,7 +876,7 @@ describe('Base', () => {
       });
 
       const usage = this.dummy.usage();
-      assert.equal(usage.trim(), 'yo dummy [options] [<baz>]');
+      assert.equal(usage.trim(), 'yo dummy [<baz>] [options]');
     });
 
     it('returns the expected usage output without arguments', function () {


### PR DESCRIPTION
yeoman/yeoman.github.io/issues/750

I've created small generator to test correct order of arguments and options:

```js
  constructor(args, opts) {
    super(args, opts);
    this.argument('a', { type: String, required: false });
    this.argument('b', { type: String, required: false });
    this.option('c', { type: String });
    this.option('d', { type: Boolean });
    this.log({
      a: this.options.a,
      b: this.options.b,
      c: this.options.c,
      d: this.options.d
    });
  }
```

And there is some output:

```sh
$ yo order
{ a: undefined, b: undefined, c: undefined, d: undefined }

$ yo order foo bar --c --d
{ a: 'foo', b: 'bar', c: 'true', d: true }

$ yo order foo bar --c=baz --d=qux
{ a: 'foo', b: 'bar', c: 'baz', d: true }
```

Seems to all be ok. Even if we change order:

```sh
$ yo order foo --c=baz bar --d=qux
{ a: 'foo', b: 'bar', c: 'baz', d: true }

$ yo order --c=baz foo bar --d=qux
{ a: 'foo', b: 'bar', c: 'baz', d: true }

$ yo order --c=baz foo --d=qux bar
{ a: 'foo', b: 'bar', c: 'baz', d: true }
```

But if we do not specify values for options, order comes to be important:

```sh
$ yo order foo --c bar --d
{ a: 'foo', b: undefined, c: 'bar', d: true }

$ yo order --c foo bar --d
{ a: 'bar', b: undefined, c: 'foo', d: true }

$ yo order --d foo bar --c
{ a: 'bar', b: undefined, c: 'true', d: true }

$ yo order --d foo --c bar
{ a: undefined, b: undefined, c: 'bar', d: true }
```

Generator help shows:

```sh
$ yo order -h
{ a: undefined, b: undefined, c: undefined, d: undefined }
Usage:
  yo order:app [options] [<a>] [<b>]

Options:
  -h,   --help          # Print the generator's options and usage
        --skip-cache    # Do not remember prompt answers             Default: false
        --skip-install  # Do not automatically install dependencies  Default: false
        --c             # Description for c
        --d             # Description for d

Arguments:
  a    Type: String  Required: false
  b    Type: String  Required: false
```

So, I propose to change order of options and arguments in help so as not to mislead users untill behaviour will not change.