### PR TITLE
Add support for the pnpm package manager

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -90,6 +90,7 @@ install.runInstall = function (installer, paths, options, spawnOptions) {
  *
  * @param {Object} [options]
  * @param {Boolean|Object} [options.npm=true] - whether to run `npm install` or can be options to pass to `dargs` as arguments
+ * @param {Boolean|Object} [options.pnpm=true] - whether to run `pnpm install` or can be options to pass to `dargs` as arguments
  * @param {Boolean|Object} [options.bower=true] - whether to run `bower install` or can be options to pass to `dargs` as arguments
  * @param {Boolean|Object} [options.yarn=false] - whether to run `yarn install` or can be options to pass to `dargs` as arguments
  * @param {Boolean} [options.skipMessage=false] - whether to log the used commands
@@ -120,6 +121,16 @@ install.installDependencies = function (options) {
     });
   }
 
+  if (options.pnpm) {
+    msg.commands.push('pnpm install');
+    commands.push(cb => {
+      this.npmInstall(null, getOptions(options.pnpm)).then(
+        val => cb(null, val),
+        cb
+      );
+    });
+  }
+
   if (options.yarn) {
     msg.commands.push('yarn install');
     commands.push(cb => {
@@ -140,7 +151,7 @@ install.installDependencies = function (options) {
     });
   }
 
-  assert(msg.commands.length, 'installDependencies needs at least one of `npm`, `bower` or `yarn` to run.');
+  assert(msg.commands.length, 'installDependencies needs at least one of `bower`, `npm`, `pnpm`, or `yarn` to run.');
 
   if (!options.skipMessage) {
     const tplValues = _.extend({
@@ -163,6 +174,7 @@ install.installDependencies = function (options) {
 
 /**
  * Receives a list of `components` and an `options` object to install through bower.
+ * See https://bower.io for information about this package manager.
  *
  * The installation will automatically run during the run loop `install` phase.
  *
@@ -177,6 +189,7 @@ install.bowerInstall = function (cmpnt, options, spawnOptions) {
 
 /**
  * Receives a list of `packages` and an `options` object to install through npm.
+ * See https://www.npmjs.com for information about this package manager.
  *
  * The installation will automatically run during the run loop `install` phase.
  *
@@ -190,7 +203,23 @@ install.npmInstall = function (pkgs, options, spawnOptions) {
 };
 
 /**
+ * Receives a list of `packages` and an `options` object to install through pnpm.
+ * See https://pnpm.js.org for information about this package manager.
+ *
+ * The installation will automatically run during the run loop `install` phase.
+ *
+ * @param {String|Array} [pkgs] Packages to install
+ * @param {Object} [options] Options to pass to `dargs` as arguments
+ * @param {Object} [spawnOptions] Options to pass `child_process.spawn`.
+ * @return {Promise} Resolved if install successful, rejected otherwise
+ */
+install.pnpmInstall = function (pkgs, options, spawnOptions) {
+  return this.runInstall('pnpm', pkgs, options, spawnOptions);
+};
+
+/**
  * Receives a list of `packages` and an `options` object to install through yarn.
+ * See https://yarnpkg.com for information about this package manager.
  *
  * The installation will automatically run during the run loop `install` phase.
  *

--- a/test/install.js
+++ b/test/install.js
@@ -72,6 +72,14 @@ describe('Base (actions/install mixin)', () => {
       });
 
       it('does not spawn anything with skipInstall', function (done) {
+        this.dummy.runInstall('pnpm', ['install']);
+        this.dummy.run(() => {
+          sinon.assert.notCalled(this.spawnCommandStub);
+          done();
+        });
+      });
+
+      it('does not spawn anything with skipInstall', function (done) {
         this.dummy.runInstall('yarn', ['install']);
         this.dummy.run(() => {
           sinon.assert.notCalled(this.spawnCommandStub);
@@ -134,6 +142,34 @@ describe('Base (actions/install mixin)', () => {
 
     it('resolve Promise on success', function () {
       const promise = this.dummy.npmInstall('yo').then(() => {
+        sinon.assert.calledOnce(this.spawnCommandStub);
+      });
+      this.dummy.run();
+      return promise;
+    });
+  });
+
+  describe('#pnpmInstall()', () => {
+    it('spawn an install process once per commands', function (done) {
+      this.dummy.pnpmInstall();
+      this.dummy.pnpmInstall();
+      this.dummy.run(() => {
+        sinon.assert.calledOnce(this.spawnCommandStub);
+        sinon.assert.calledWithExactly(this.spawnCommandStub, 'pnpm', ['install'], {});
+        done();
+      });
+    });
+
+    it('run with options', function (done) {
+      this.dummy.pnpmInstall('yo', {save: true});
+      this.dummy.run(() => {
+        sinon.assert.calledWithExactly(this.spawnCommandStub, 'pnpm', ['install', 'yo', '--save'], {});
+        done();
+      });
+    });
+
+    it('resolve Promise on success', function () {
+      const promise = this.dummy.pnpmInstall('yo').then(() => {
         sinon.assert.calledOnce(this.spawnCommandStub);
       });
       this.dummy.run();


### PR DESCRIPTION
Update `install.runInstall()` to support the **pnpm** package manager, and add an `install.pnpmInstall()` helper.