### PR TITLE
Make tests robust

### DIFF
--- a/test/prompt-suggestion.js
+++ b/test/prompt-suggestion.js
@@ -9,6 +9,8 @@ const FileEditor = require('mem-fs-editor');
 const Storage = require('../lib/util/storage');
 const promptSuggestion = require('../lib/util/prompt-suggestion');
 
+/* eslint max-nested-callbacks: ["warn", 6] */
+
 describe('PromptSuggestion', () => {
   beforeEach(function () {
     this.memFs = env.createEnv().sharedFs;

--- a/test/user.js
+++ b/test/user.js
@@ -10,6 +10,8 @@ const shell = require('shelljs');
 const sinon = require('sinon');
 const Base = require('..');
 
+/* eslint max-nested-callbacks: ["warn", 5] */
+
 const tmpdir = path.join(os.tmpdir(), 'yeoman-user');
 
 describe('Base#user', () => {

--- a/test/user.js
+++ b/test/user.js
@@ -14,7 +14,9 @@ const Base = require('..');
 
 const tmpdir = path.join(os.tmpdir(), 'yeoman-user');
 
-describe('Base#user', () => {
+describe('Base#user', function () {
+  this.timeout(5000);
+
   beforeEach(function () {
     this.prevCwd = process.cwd();
     this.tmp = tmpdir;


### PR DESCRIPTION
Currently yeoman generator is always showing up in [citgm](https://github.com/nodejs/citgm) because of test timeouts. When I checked travis, I realized this is happening quite often because the tests are just quite heavy.

To fix that I increased the maximum timeout of those tests and also went ahead and fixed some warnings.