### PR TITLE
Overload composeWith method to allow a generator class along its path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 .nyc_output
+yarn.lock

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha All",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": ["--timeout", "999999", "--colors", "${workspaceFolder}/test"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Current File",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": ["--timeout", "999999", "--colors", "${file}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -496,23 +496,32 @@ class Generator extends EventEmitter {
 
   /**
    * Compose this generator with another one.
-   * @param  {String} namespace  The generator namespace to compose with
+   * @param  {String|Object} generator  The path to the generator module or an object (see examples)
    * @param  {Object} options    The options passed to the Generator
-   * @param  {Object} [settings] Settings hash on the composition relation
-   * @param  {string} [settings.local]        Path to a locally stored generator
-   * @param  {String} [settings.link="weak"]  If "strong", the composition will occured
-   *                                          even when the composition is initialized by
-   *                                          the end user
-   * @return {this}
+   * @return {this}    This generator
    *
    * @example <caption>Using a peerDependency generator</caption>
    * this.composeWith('bootstrap', { sass: true });
    *
    * @example <caption>Using a direct dependency generator</caption>
    * this.composeWith(require.resolve('generator-bootstrap/app/main.js'), { sass: true });
+   *
+   * @example <caption>Passing a Generator class</caption>
+   * this.composeWith({ Generator: MyGenerator, path: '../generator-bootstrap/app/main.js' }, { sass: true });
    */
-  composeWith(modulePath, options) {
-    let generator;
+  composeWith(generator, options) {
+    let instantiatedGenerator;
+
+    const instantiate = (Generator, path) => {
+      Generator.resolved = require.resolve(path);
+      Generator.namespace = this.env.namespace(path);
+
+      return this.env.instantiate(Generator, {
+        options,
+        arguments: options.arguments
+      });
+    };
+
     options = options || {};
 
     // Pass down the default options so they're correctly mirrored down the chain.
@@ -528,29 +537,36 @@ class Generator extends EventEmitter {
       options
     );
 
-    try {
-      const Generator = require(modulePath); // eslint-disable-line import/no-dynamic-require
-      Generator.resolved = require.resolve(modulePath);
-      Generator.namespace = this.env.namespace(modulePath);
-      generator = this.env.instantiate(Generator, {
-        options,
-        arguments: options.arguments
-      });
-    } catch (err) {
-      if (err.code === 'MODULE_NOT_FOUND') {
-        generator = this.env.create(modulePath, {
-          options,
-          arguments: options.arguments
-        });
-      } else {
-        throw err;
+    if (typeof generator === 'string') {
+      try {
+        const Generator = require(generator); // eslint-disable-line import/no-dynamic-require
+        instantiatedGenerator = instantiate(Generator, generator);
+      } catch (err) {
+        if (err.code === 'MODULE_NOT_FOUND') {
+          instantiatedGenerator = this.env.create(generator, {
+            options,
+            arguments: options.arguments
+          });
+        } else {
+          throw err;
+        }
       }
+    } else {
+      assert(
+        generator.Generator,
+        'When passing an object to Generator#composeWith include the generator class to run in the Generator property'
+      );
+      assert(
+        typeof generator.path === 'string',
+        'When passing an object to Generator#composeWith include the path where to the generator in the path property'
+      );
+      instantiatedGenerator = instantiate(generator.Generator, generator.path);
     }
 
     if (this._running) {
-      generator.run();
+      instantiatedGenerator.run();
     } else {
-      this._composedWith.push(generator);
+      this._composedWith.push(instantiatedGenerator);
     }
 
     return this;

--- a/lib/util/prompt-suggestion.js
+++ b/lib/util/prompt-suggestion.js
@@ -36,8 +36,8 @@ const getCheckboxDefault = (question, defaultValue) => {
  * @private
  */
 const getListDefault = (question, defaultValue) => {
-  const choiceValues = question.choices.map(
-    choice => (typeof choice === 'object' ? choice.value : choice)
+  const choiceValues = question.choices.map(choice =>
+    typeof choice === 'object' ? choice.value : choice
   );
   return choiceValues.indexOf(defaultValue);
 };

--- a/test/base.js
+++ b/test/base.js
@@ -736,6 +736,7 @@ describe('Base', () => {
 
     it('runs the composed generators', function(done) {
       this.dummy.composeWith('composed:gen');
+
       const runSpy = sinon.spy(this.dummy, 'run');
 
       // I use a setTimeout here just to make sure composeWith() doesn't start the
@@ -753,6 +754,23 @@ describe('Base', () => {
           done();
         });
       }, 100);
+    });
+
+    it('runs the composed Generator class in the passed path', function() {
+      this.stubPath = path.join(__dirname, 'fixtures/generator-mocha');
+
+      this.dummy.composeWith({
+        Generator: this.GenCompose,
+        path: this.stubPath
+      });
+
+      return this.dummy.run().then(() => {
+        assert.equal(this.spy.firstCall.thisValue.options.namespace, 'mocha');
+        assert.equal(
+          this.spy.firstCall.thisValue.options.resolved,
+          require.resolve(this.stubPath)
+        );
+      });
     });
 
     it('run the composed generator even if main generator is already running.', function() {


### PR DESCRIPTION
Allow to compose with a Generator directly instead of requiring its source code dynamically.

For convenience, and I have no problem with removing this changes if needed:
- Added yarn.lock to .gitignore
- Added VSCode debugging configuration