### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/test/install.js
+++ b/test/install.js
@@ -52,7 +52,7 @@ describe('Base (actions/install mixin)', () => {
         sinon.assert.calledWithExactly(
           this.spawnCommandStub,
           'nestedScript',
-          ['install', 'path1', 'path2', '--save'],
+          ['install', 'path1', 'path2'],
           spawnEnv
         );
         done();
@@ -221,7 +221,7 @@ describe('Base (actions/install mixin)', () => {
             this.dummy,
             [
               'Skipping install command: ' +
-                chalk.yellow('npm install some-package --save --cache-min 86400')
+                chalk.yellow('npm install some-package --cache-min 86400')
             ]
           );
           done();
@@ -278,7 +278,7 @@ describe('Base (actions/install mixin)', () => {
         sinon.assert.calledWithExactly(
           this.spawnCommandStub,
           'npm',
-          ['install', 'yo', '--save', '--cache-min', 86400],
+          ['install', 'yo', '--cache-min', 86400],
           {}
         );
         done();


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358