### PR TITLE
Add pnpm support

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -40,6 +40,11 @@ install.scheduleInstallTask = function(installer, paths, options, spawnOptions) 
     args = args.concat(['--cache-min', 24 * 60 * 60]);
   }
 
+  // Only for pnpm, prefer offline
+  if (installer === 'pnpm') {
+    args = args.concat(['--prefer-offline']);
+  }
+
   // Return early if we're skipping installation
   if (this.options.skipInstall || this.options['skip-install']) {
     this.log(
@@ -135,6 +140,11 @@ install.installDependencies = function(options) {
     this.npmInstall(null, getOptions(options.npm));
   }
 
+  if (options.pnpm) {
+    msg.commands.push('pnpm install');
+    this.pnpmInstall(null, getOptions(options.pnpm));
+  }
+
   if (options.yarn) {
     msg.commands.push('yarn install');
     this.yarnInstall(null, getOptions(options.yarn));
@@ -188,6 +198,19 @@ install.bowerInstall = function(cmpnt, options, spawnOptions) {
  */
 install.npmInstall = function(pkgs, options, spawnOptions) {
   this.scheduleInstallTask('npm', pkgs, options, spawnOptions);
+};
+
+/**
+ * Receives a list of `packages` and an `options` object to install through pnpm.
+ *
+ * The installation will automatically run during the run loop `install` phase.
+ *
+ * @param {String|Array} [pkgs] Packages to install
+ * @param {Object} [options] Options to pass to `dargs` as arguments
+ * @param {Object} [spawnOptions] Options to pass `child_process.spawn`.
+ */
+install.pnpmInstall = function(pkgs, options, spawnOptions) {
+  this.scheduleInstallTask('pnpm', pkgs, options, spawnOptions);
 };
 
 /**

--- a/test/install.js
+++ b/test/install.js
@@ -286,6 +286,36 @@ describe('Base (actions/install mixin)', () => {
     });
   });
 
+  describe('#pnpmInstall()', () => {
+    it('spawn an install process once per commands', done => {
+      this.dummy.pnpmInstall();
+      this.dummy.pnpmInstall();
+      this.dummy.run(() => {
+        sinon.assert.calledOnce(this.spawnCommandStub);
+        sinon.assert.calledWithExactly(
+          this.spawnCommandStub,
+          'pnpm',
+          ['install', '--prefer-offline'],
+          {}
+        );
+        done();
+      });
+    });
+
+    it('run with options', done => {
+      this.dummy.pnpmInstall('yo', { save: true });
+      this.dummy.run(() => {
+        sinon.assert.calledWithExactly(
+          this.spawnCommandStub,
+          'pnpm',
+          ['install', 'yo', '--save', '--prefer-offline'],
+          {}
+        );
+        done();
+      });
+    });
+  });
+
   describe('#yarnInstall()', () => {
     it('spawn an install process once per commands', done => {
       this.dummy.yarnInstall();


### PR DESCRIPTION
This commit adds a `pnpmInstall` method to the generator to allow managing dependencies with [pnpm](https://github.com/pnpm/pnpm).

Motivation: adding pnpm support to downstream project oclif (https://github.com/oclif/oclif/issues/227)