### PR TITLE
Run separate install process if spawnOptions differs

### DIFF
--- a/lib/actions/install.js
+++ b/lib/actions/install.js
@@ -86,7 +86,7 @@ install.scheduleInstallTask = function(installer, paths, options, spawnOptions) 
         });
     },
     {
-      once: installer + ' ' + args.join(' '),
+      once: installer + ' ' + args.join(' ') + ' ' + JSON.stringify(spawnOptions),
       run: false
     }
   );

--- a/test/install.js
+++ b/test/install.js
@@ -284,6 +284,15 @@ describe('Base (actions/install mixin)', () => {
         done();
       });
     });
+
+    it('spawn separate install processes if spawnOptions differs', done => {
+      this.dummy.npmInstall(null, null, { cwd: 'path1' });
+      this.dummy.npmInstall(null, null, { cwd: 'path2' });
+      this.dummy.run(() => {
+        sinon.assert.calledTwice(this.spawnCommandStub);
+        done();
+      });
+    });
   });
 
   describe('#yarnInstall()', () => {
@@ -307,6 +316,15 @@ describe('Base (actions/install mixin)', () => {
           ['add', 'yo', '--dev'],
           {}
         );
+        done();
+      });
+    });
+
+    it('spawn separate install processes if spawnOptions differs', done => {
+      this.dummy.yarnInstall(null, null, { cwd: 'path1' });
+      this.dummy.yarnInstall(null, null, { cwd: 'path2' });
+      this.dummy.run(() => {
+        sinon.assert.calledTwice(this.spawnCommandStub);
         done();
       });
     });


### PR DESCRIPTION
With the current behavior, if a generator tries to do something like this:
```js
this.npmInstall();
this.npmInstall(null, null, {cwd: this.destinationPath('some-other-path')});
```
the second call is ignored.

If we want to create a full-stack generator (like I'm doing) that needs to run `npm install` in multiple paths, we are stuck.

This PR takes in account the unicity of the `spawnOptions` parameter to dedupe the install calls, fixing the current behavior.

