### PR TITLE
Expose addMethod

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -378,6 +378,32 @@ class Generator extends EventEmitter {
     });
   }
 
+  queueMethod(method, methodName, queueName, reject = () => {}) {
+    const self = this;
+    queueName = queueName || 'default';
+    debug(`Queueing ${methodName} in ${queueName}`);
+    self.env.runLoop.add(queueName, completed => {
+      debug(`Running ${methodName}`);
+      self.emit(`method:${methodName}`);
+
+      runAsync(function() {
+        self.async = () => this.async();
+        return method.apply(self, self.args);
+      })()
+        .then(completed)
+        .catch(err => {
+          debug(`An error occured while running ${methodName}`, err);
+
+          // Ensure we emit the error event outside the promise context so it won't be
+          // swallowed when there's no listeners.
+          setImmediate(() => {
+            self.emit('error', err);
+            reject(err);
+          });
+        });
+    });
+  }
+
   /**
    * Runs the generator, scheduling prototype methods on a run queue. Method names
    * will determine the order each method is run. Methods without special names
@@ -415,38 +441,13 @@ class Generator extends EventEmitter {
         return name.charAt(0) !== '_' && name !== 'constructor';
       }
 
-      function addMethod(method, methodName, queueName) {
-        queueName = queueName || 'default';
-        debug(`Queueing ${methodName} in ${queueName}`);
-        self.env.runLoop.add(queueName, completed => {
-          debug(`Running ${methodName}`);
-          self.emit(`method:${methodName}`);
-
-          runAsync(function() {
-            self.async = () => this.async();
-            return method.apply(self, self.args);
-          })()
-            .then(completed)
-            .catch(err => {
-              debug(`An error occured while running ${methodName}`, err);
-
-              // Ensure we emit the error event outside the promise context so it won't be
-              // swallowed when there's no listeners.
-              setImmediate(() => {
-                self.emit('error', err);
-                reject(err);
-              });
-            });
-        });
-      }
-
       function addInQueue(name) {
         const item = Object.getPrototypeOf(self)[name];
         const queueName = self.env.runLoop.queueNames.indexOf(name) === -1 ? null : name;
 
         // Name points to a function; run it!
         if (typeof item === 'function') {
-          return addMethod(item, name, queueName);
+          return self.queueMethod(item, name, queueName, reject);
         }
 
         // Not a queue hash; stop
@@ -460,7 +461,7 @@ class Generator extends EventEmitter {
             return;
           }
 
-          addMethod(method, methodName, queueName);
+          self.queueMethod(method, methodName, queueName, reject);
         });
       }
 

--- a/test/base.js
+++ b/test/base.js
@@ -1174,4 +1174,53 @@ describe('Base', () => {
       assert.equal(this.dummy.rootGeneratorVersion(), '1.0.0');
     });
   });
+
+  describe('#queueMethod()', () => {
+    beforeEach(function() {
+      this.Generator = class extends Base {
+        constructor(args, opts) {
+          super(args, opts);
+
+          this.queueMethod(function() {
+            this.queue = this.options.testQueue;
+          }, 'testQueue');
+        }
+
+        exec() {}
+      };
+    });
+
+    it('queued method is executed', function(done) {
+      const gen = new this.Generator({
+        resolved: resolveddir,
+        namespace: 'dummy',
+        env: this.env,
+        testQueue: 'This value'
+      });
+
+      gen.run().then(() => {
+        assert.equal(gen.queue, 'This value');
+        done();
+      });
+    });
+
+    it('queued method is executed by derived generator', function(done) {
+      const Derived = class extends this.Generator {
+        // At least a method is required otherwise will fail. Is this a problem?
+        exec() {}
+      };
+
+      const derivedGen = new Derived({
+        resolved: resolveddir,
+        namespace: 'dummy',
+        env: this.env,
+        testQueue: 'That value'
+      });
+
+      derivedGen.run().then(() => {
+        assert.equal(derivedGen.queue, 'That value');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Exposing addMethod as queueMethod will allow more powerful derived work.

Should fix https://github.com/yeoman/generator/issues/1112
Example: https://github.com/yeoman/generator/blob/4b4ebde523643c474e586602f0631bce4b36b037/test/base.js#L1180-L1190

The queued function will execute at derived classes:
https://github.com/yeoman/generator/blob/4b4ebde523643c474e586602f0631bce4b36b037/test/base.js#L1207-L1224