### PR TITLE
Add rootName parameter to _getStorage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -613,12 +613,13 @@ class Generator extends EventEmitter {
 
   /**
    * Return a storage instance.
+   * @param  {String} rootName  The rootName in which is stored inside .yo-rc.json
    * @return {Storage} Generator storage
    * @private
    */
-  _getStorage() {
+  _getStorage(rootName = this.rootGeneratorName()) {
     const storePath = path.join(this.destinationRoot(), '.yo-rc.json');
-    return new Storage(this.rootGeneratorName(), this.fs, storePath);
+    return new Storage(rootName, this.fs, storePath);
   }
 
   /**


### PR DESCRIPTION
This is useful for generators that uses generators from multiple packages.