### PR TITLE
Add support to array on composeWith

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -504,7 +504,7 @@ class Generator extends EventEmitter {
 
   /**
    * Compose this generator with another one.
-   * @param  {String|Object} generator  The path to the generator module or an object (see examples)
+   * @param  {String|Object|Array} generator  The path to the generator module or an object (see examples)
    * @param  {Object} options    The options passed to the Generator
    * @return {this}    This generator
    *
@@ -519,6 +519,13 @@ class Generator extends EventEmitter {
    */
   composeWith(generator, options) {
     let instantiatedGenerator;
+
+    if (Array.isArray(generator)) {
+      generator.forEach(gen => {
+        this.composeWith(gen, options);
+      });
+      return this;
+    }
 
     const instantiate = (Generator, path) => {
       Generator.resolved = require.resolve(path);

--- a/test/generators-compose-workflow.js
+++ b/test/generators-compose-workflow.js
@@ -1,0 +1,387 @@
+'use strict';
+const os = require('os');
+const path = require('path');
+const sinon = require('sinon');
+const makeDir = require('make-dir');
+const mockery = require('mockery');
+const yeoman = require('yeoman-environment');
+
+mockery.enable({
+  warnOnReplace: false,
+  warnOnUnregistered: false
+});
+
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const { TestAdapter } = require('yeoman-test/lib/adapter');
+const Base = require('..');
+
+const tmpdir = path.join(os.tmpdir(), 'yeoman-base');
+const resolveddir = path.join(os.tmpdir(), 'yeoman-base-generator');
+
+describe('Multiples generators', () => {
+  beforeEach(helpers.setUpTestDirectory(tmpdir));
+
+  beforeEach(function() {
+    this.env = yeoman.createEnv([], { 'skip-install': true }, new TestAdapter());
+    makeDir.sync(resolveddir);
+    this.Dummy = class extends Base {};
+    this.spyExec = sinon.spy();
+    this.Dummy.prototype.exec = this.spyExec;
+
+    this.dummy = new this.Dummy(['bar', 'baz', 'bom'], {
+      foo: false,
+      something: 'else',
+      // Mandatory options, created by the `env#create()` helper
+      resolved: resolveddir,
+      namespace: 'dummy',
+      env: this.env,
+      'skip-install': true
+    });
+  });
+
+  describe('#composeWith() with multiples generators', () => {
+    beforeEach(function() {
+      this.dummy = new this.Dummy([], {
+        resolved: 'unknown',
+        namespace: 'dummy',
+        env: this.env,
+        'skip-install': true,
+        'force-install': true,
+        'skip-cache': true
+      });
+
+      this.spyExec1 = sinon.spy();
+      this.spyInit1 = sinon.spy();
+      this.spyWrite1 = sinon.spy();
+      this.spyEnd1 = sinon.spy();
+
+      this.GenCompose1 = class extends Base {};
+      this.GenCompose1.prototype.exec = this.spyExec1;
+      this.GenCompose1.prototype.initializing = this.spyInit1;
+      this.GenCompose1.prototype.writing = this.spyWrite1;
+      this.GenCompose1.prototype.end = this.spyEnd1;
+
+      this.spyExec2 = sinon.spy();
+      this.spyInit2 = sinon.spy();
+      this.spyWrite2 = sinon.spy();
+      this.spyEnd2 = sinon.spy();
+
+      this.GenCompose2 = class extends Base {};
+      this.GenCompose2.prototype.exec = this.spyExec2;
+      this.GenCompose2.prototype.initializing = this.spyInit2;
+      this.GenCompose2.prototype.writing = this.spyWrite2;
+      this.GenCompose2.prototype.end = this.spyEnd2;
+
+      this.env.registerStub(this.GenCompose1, 'composed:gen');
+      this.env.registerStub(this.GenCompose2, 'composed:gen2');
+    });
+
+    it('runs multiple composed generators', function(done) {
+      this.dummy.composeWith(['composed:gen', 'composed:gen2']);
+
+      const runSpy = sinon.spy(this.dummy, 'run');
+
+      // I use a setTimeout here just to make sure composeWith() doesn't start the
+      // generator before the base one is ran.
+      setTimeout(() => {
+        this.dummy.run().then(() => {
+          sinon.assert.callOrder(
+            runSpy,
+            this.spyInit1,
+            this.spyInit2,
+            this.spyExec,
+            this.spyExec1,
+            this.spyExec2,
+            this.spyWrite1,
+            this.spyWrite2,
+            this.spyEnd1,
+            this.spyEnd2
+          );
+          assert.equal(this.spyExec1.thisValues[0].options.skipInstall, true);
+          assert.equal(this.spyExec1.thisValues[0].options['skip-install'], true);
+          assert.equal(this.spyExec1.thisValues[0].options.forceInstall, true);
+          assert.equal(this.spyExec1.thisValues[0].options['force-install'], true);
+          assert.equal(this.spyExec1.thisValues[0].options.skipCache, true);
+          assert.equal(this.spyExec1.thisValues[0].options['skip-cache'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.skipInstall, true);
+          assert.equal(this.spyExec2.thisValues[0].options['skip-install'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.forceInstall, true);
+          assert.equal(this.spyExec2.thisValues[0].options['force-install'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.skipCache, true);
+          assert.equal(this.spyExec2.thisValues[0].options['skip-cache'], true);
+          assert(this.spyInit1.calledAfter(runSpy));
+          assert(this.spyInit2.calledAfter(this.spyInit1));
+          assert(this.spyExec1.calledAfter(this.spyInit2));
+          assert(this.spyExec2.calledAfter(this.spyExec1));
+          done();
+        });
+      }, 100);
+    });
+
+    it('runs multiple composed generators (reverse)', function(done) {
+      this.dummy.composeWith(['composed:gen2', 'composed:gen']);
+
+      const runSpy = sinon.spy(this.dummy, 'run');
+
+      // I use a setTimeout here just to make sure composeWith() doesn't start the
+      // generator before the base one is ran.
+      setTimeout(() => {
+        this.dummy.run().then(() => {
+          sinon.assert.callOrder(
+            runSpy,
+            this.spyInit2,
+            this.spyInit1,
+            this.spyExec,
+            this.spyExec2,
+            this.spyExec1,
+            this.spyWrite2,
+            this.spyWrite1,
+            this.spyEnd2,
+            this.spyEnd1
+          );
+          assert.equal(this.spyExec1.thisValues[0].options.skipInstall, true);
+          assert.equal(this.spyExec1.thisValues[0].options['skip-install'], true);
+          assert.equal(this.spyExec1.thisValues[0].options.forceInstall, true);
+          assert.equal(this.spyExec1.thisValues[0].options['force-install'], true);
+          assert.equal(this.spyExec1.thisValues[0].options.skipCache, true);
+          assert.equal(this.spyExec1.thisValues[0].options['skip-cache'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.skipInstall, true);
+          assert.equal(this.spyExec2.thisValues[0].options['skip-install'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.forceInstall, true);
+          assert.equal(this.spyExec2.thisValues[0].options['force-install'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.skipCache, true);
+          assert.equal(this.spyExec2.thisValues[0].options['skip-cache'], true);
+          assert(this.spyInit2.calledAfter(runSpy));
+          assert(this.spyInit1.calledAfter(this.spyInit2));
+          assert(this.spyExec2.calledAfter(this.spyInit1));
+          assert(this.spyExec1.calledAfter(this.spyExec2));
+          done();
+        });
+      }, 100);
+    });
+
+    it('runs 3 composed generators', function(done) {
+      this.spyExec3 = sinon.spy();
+      this.spyInit3 = sinon.spy();
+      const GenCompose3 = class extends Base {};
+      GenCompose3.prototype.exec = this.spyExec3;
+      GenCompose3.prototype.initializing = this.spyInit3;
+
+      this.env.registerStub(GenCompose3, 'composed:gen3');
+
+      this.dummy.composeWith(['composed:gen', 'composed:gen2', 'composed:gen3']);
+
+      const runSpy = sinon.spy(this.dummy, 'run');
+
+      // I use a setTimeout here just to make sure composeWith() doesn't start the
+      // generator before the base one is ran.
+      setTimeout(() => {
+        this.dummy.run().then(() => {
+          sinon.assert.callOrder(
+            runSpy,
+            this.spyInit1,
+            this.spyInit2,
+            this.spyInit3,
+            this.spyExec,
+            this.spyExec1,
+            this.spyExec2,
+            this.spyExec3,
+            this.spyWrite1,
+            this.spyWrite2,
+            this.spyEnd1,
+            this.spyEnd2
+          );
+          assert.equal(this.spyExec1.thisValues[0].options.skipInstall, true);
+          assert.equal(this.spyExec1.thisValues[0].options['skip-install'], true);
+          assert.equal(this.spyExec1.thisValues[0].options.forceInstall, true);
+          assert.equal(this.spyExec1.thisValues[0].options['force-install'], true);
+          assert.equal(this.spyExec1.thisValues[0].options.skipCache, true);
+          assert.equal(this.spyExec1.thisValues[0].options['skip-cache'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.skipInstall, true);
+          assert.equal(this.spyExec2.thisValues[0].options['skip-install'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.forceInstall, true);
+          assert.equal(this.spyExec2.thisValues[0].options['force-install'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.skipCache, true);
+          assert.equal(this.spyExec2.thisValues[0].options['skip-cache'], true);
+          assert.equal(this.spyExec3.thisValues[0].options.skipInstall, true);
+          assert.equal(this.spyExec3.thisValues[0].options['skip-install'], true);
+          assert.equal(this.spyExec3.thisValues[0].options.forceInstall, true);
+          assert.equal(this.spyExec3.thisValues[0].options['force-install'], true);
+          assert.equal(this.spyExec3.thisValues[0].options.skipCache, true);
+          assert.equal(this.spyExec3.thisValues[0].options['skip-cache'], true);
+          assert(this.spyInit1.calledAfter(runSpy));
+          assert(this.spyInit2.calledAfter(this.spyInit1));
+          assert(this.spyInit3.calledAfter(this.spyInit2));
+          assert(this.spyExec1.calledAfter(this.spyInit3));
+          assert(this.spyExec2.calledAfter(this.spyExec1));
+          assert(this.spyExec3.calledAfter(this.spyExec2));
+          done();
+        });
+      }, 100);
+    });
+
+    it('runs multiple composed generators inside a running generator', function(done) {
+      const Dummy2 = class extends this.Dummy {};
+
+      const writingSpy1 = sinon.spy();
+      const writingSpy2 = sinon.spy();
+      const endSpy = sinon.spy();
+      Dummy2.prototype.end = endSpy;
+
+      Dummy2.prototype.writing = {
+        compose: function() {
+          // Initializing and default is queue and called next (before writingSpy2)
+          // Writing is queue after already queued functions (after writingSpy2)
+          this.composeWith(['composed:gen', 'composed:gen2']);
+          writingSpy1();
+        },
+        writingSpy2: function() {
+          writingSpy2();
+        }
+      };
+
+      this.dummy2 = new Dummy2([], {
+        resolved: 'unknown',
+        namespace: 'dummy',
+        env: this.env,
+        'skip-install': true,
+        'force-install': true,
+        'skip-cache': true
+      });
+
+      const runSpy = sinon.spy(this.dummy2, 'run');
+
+      // I use a setTimeout here just to make sure composeWith() doesn't start the
+      // generator before the base one is ran.
+      setTimeout(() => {
+        this.dummy2.run().then(() => {
+          sinon.assert.callOrder(
+            runSpy,
+            writingSpy1,
+            this.spyInit1,
+            this.spyInit2,
+            this.spyExec1,
+            this.spyExec2,
+            writingSpy2,
+            this.spyWrite1,
+            this.spyWrite2,
+            endSpy,
+            this.spyEnd1,
+            this.spyEnd2
+          );
+          assert.equal(this.spyExec1.thisValues[0].options.skipInstall, true);
+          assert.equal(this.spyExec1.thisValues[0].options['skip-install'], true);
+          assert.equal(this.spyExec1.thisValues[0].options.forceInstall, true);
+          assert.equal(this.spyExec1.thisValues[0].options['force-install'], true);
+          assert.equal(this.spyExec1.thisValues[0].options.skipCache, true);
+          assert.equal(this.spyExec1.thisValues[0].options['skip-cache'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.skipInstall, true);
+          assert.equal(this.spyExec2.thisValues[0].options['skip-install'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.forceInstall, true);
+          assert.equal(this.spyExec2.thisValues[0].options['force-install'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.skipCache, true);
+          assert.equal(this.spyExec2.thisValues[0].options['skip-cache'], true);
+          assert(writingSpy1.calledAfter(runSpy));
+          assert(this.spyInit1.calledAfter(writingSpy1));
+          assert(this.spyInit2.calledAfter(this.spyInit1));
+          assert(this.spyExec1.calledAfter(this.spyInit2));
+          assert(this.spyExec2.calledAfter(this.spyExec1));
+          assert(writingSpy2.calledAfter(this.spyExec2));
+          assert(this.spyWrite1.calledAfter(writingSpy2));
+          assert(this.spyWrite2.calledAfter(this.spyWrite1));
+          assert(endSpy.calledAfter(this.spyWrite2));
+          assert(this.spyEnd1.calledAfter(endSpy));
+          assert(this.spyEnd2.calledAfter(this.spyEnd1));
+          done();
+        });
+      }, 100);
+    });
+
+    it('runs multiple composed generators inside a running generator', function(done) {
+      const Dummy2 = class extends this.Dummy {};
+
+      const writingSpy1 = sinon.spy();
+      const writingSpy2 = sinon.spy();
+      const writingSpy3 = sinon.spy();
+      const endSpy = sinon.spy();
+
+      Dummy2.prototype.end = endSpy;
+      Dummy2.prototype.writing = {
+        compose1: function() {
+          // Initializing and default is queue and called next (before writingSpy2)
+          // Writing is queue after already queued functions (after writingSpy2, compose2, writingSpy3)
+          this.composeWith('composed:gen');
+          writingSpy1();
+        },
+        writingSpy2: function() {
+          writingSpy2();
+        },
+        compose2: function() {
+          this.composeWith('composed:gen2');
+        },
+        writingSpy3: function() {
+          writingSpy3();
+        }
+      };
+
+      this.dummy2 = new Dummy2([], {
+        resolved: 'unknown',
+        namespace: 'dummy',
+        env: this.env,
+        'skip-install': true,
+        'force-install': true,
+        'skip-cache': true
+      });
+
+      const runSpy = sinon.spy(this.dummy2, 'run');
+
+      // I use a setTimeout here just to make sure composeWith() doesn't start the
+      // generator before the base one is ran.
+      setTimeout(() => {
+        this.dummy2.run().then(() => {
+          sinon.assert.callOrder(
+            runSpy,
+            writingSpy1,
+            this.spyInit1,
+            this.spyExec1,
+            writingSpy2,
+            this.spyInit2,
+            this.spyExec2,
+            writingSpy3,
+            this.spyWrite1,
+            this.spyWrite2,
+            endSpy,
+            this.spyEnd1,
+            this.spyEnd2
+          );
+          assert.equal(this.spyExec1.thisValues[0].options.skipInstall, true);
+          assert.equal(this.spyExec1.thisValues[0].options['skip-install'], true);
+          assert.equal(this.spyExec1.thisValues[0].options.forceInstall, true);
+          assert.equal(this.spyExec1.thisValues[0].options['force-install'], true);
+          assert.equal(this.spyExec1.thisValues[0].options.skipCache, true);
+          assert.equal(this.spyExec1.thisValues[0].options['skip-cache'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.skipInstall, true);
+          assert.equal(this.spyExec2.thisValues[0].options['skip-install'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.forceInstall, true);
+          assert.equal(this.spyExec2.thisValues[0].options['force-install'], true);
+          assert.equal(this.spyExec2.thisValues[0].options.skipCache, true);
+          assert.equal(this.spyExec2.thisValues[0].options['skip-cache'], true);
+          assert(writingSpy1.calledAfter(runSpy));
+          assert(this.spyInit1.calledAfter(writingSpy1));
+          assert(this.spyExec1.calledAfter(this.spyInit1));
+          assert(writingSpy2.calledAfter(this.spyExec1));
+          assert(this.spyInit2.calledAfter(writingSpy2));
+          assert(this.spyExec2.calledAfter(this.spyExec1));
+          assert(writingSpy3.calledAfter(this.spyExec2));
+          assert(this.spyWrite1.calledAfter(writingSpy3));
+          assert(this.spyWrite2.calledAfter(this.spyWrite1));
+          assert(endSpy.calledAfter(this.spyWrite2));
+          assert(this.spyEnd1.calledAfter(endSpy));
+          assert(this.spyEnd2.calledAfter(this.spyEnd1));
+          done();
+        });
+      }, 100);
+    });
+  });
+});

--- a/test/storage.js
+++ b/test/storage.js
@@ -153,6 +153,9 @@ describe('Storage', () => {
         this.store2.set('bar', 'foo');
         this.store.set('foo', 'bar');
 
+        assert.equal(this.store2.get('foo'), 'bar');
+        assert.equal(this.store.get('bar'), 'foo');
+
         const json = this.fs.readJSON(this.storePath);
         assert.equal(json.test.foo, 'bar');
         assert.equal(json.test.bar, 'foo');


### PR DESCRIPTION
Add a shortcut to call multiple generators on composeWith.
Add a workflow test with multiple generators.