### PR TITLE
Add option to use another detect-conflict implementation on Conflicter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -116,11 +116,7 @@ class Generator extends EventEmitter {
     this.async = () => () => {};
 
     this.fs = FileEditor.create(this.env.sharedFs);
-    this.conflicter = new Conflicter(
-      this.env.adapter,
-      this.options.force,
-      this.options.bail
-    );
+    this.conflicter = new Conflicter(this.env, this.options.force, this.options.bail);
 
     // Mirror the adapter log method on the generator.
     //

--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -28,17 +28,18 @@ const ConflictError = typedError({
  * @constructor
  * @property {Boolean} force - same as the constructor argument
  *
- * @param  {TerminalAdapter} adapter - The generator adapter
+ * @param  {Object}    env - The generator environment or adapter (TerminalAdapter)
  * @param  {Boolean} force - When set to true, we won't check for conflict. (the
  *                           conflicter become a passthrough)
  * @param  {Boolean} bail - When set to true, we will abort on first conflict. (used for
  *                           testing reproducibility)
  */
 class Conflicter {
-  constructor(adapter, force, bail = false) {
+  constructor(env, force, bail = false) {
     this.force = force === true;
     this.bail = bail === true;
-    this.adapter = adapter;
+    this.adapter = env.adapter || env;
+    this.detectConflict = env.detectConflict || detectConflict;
     this.conflicts = [];
   }
 
@@ -127,7 +128,7 @@ class Conflicter {
       return;
     }
 
-    if (detectConflict(file.path, file.contents)) {
+    if (this.detectConflict(file.path, file.contents)) {
       this.adapter.log.conflict(rfilepath);
       if (this.bail) {
         this.adapter.log.writeln('Aborting ...');


### PR DESCRIPTION
This will allow to make use of jsdiff instead of detect-conflict to ignoring indentation changes when detecting changes on js, css files.