### PR TITLE
Migrate from detect-conflict to diff (JsDiff)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -116,11 +116,12 @@ class Generator extends EventEmitter {
     this.async = () => () => {};
 
     this.fs = FileEditor.create(this.env.sharedFs);
-    this.conflicter = new Conflicter(
-      this.env.adapter,
-      this.options.force,
-      this.options.bail
-    );
+
+    const self = this;
+    this.conflicter = new Conflicter(this.env.adapter, this.options.force, {
+      bail: self.options.bail,
+      ignoreWhitespace: self.options.whitespace
+    });
 
     // Mirror the adapter log method on the generator.
     //

--- a/lib/index.js
+++ b/lib/index.js
@@ -117,11 +117,10 @@ class Generator extends EventEmitter {
 
     this.fs = FileEditor.create(this.env.sharedFs);
 
-    const self = this;
     this.conflicter = new Conflicter(this.env.adapter, this.options.force, {
-      bail: self.options.bail,
-      ignoreWhitespace: self.options.whitespace,
-      skipRegenerate: self.options.skipRegenerate
+      bail: this.options.bail,
+      ignoreWhitespace: this.options.whitespace,
+      skipRegenerate: this.options.skipRegenerate
     });
 
     // Mirror the adapter log method on the generator.

--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,8 @@ class Generator extends EventEmitter {
     const self = this;
     this.conflicter = new Conflicter(this.env.adapter, this.options.force, {
       bail: self.options.bail,
-      ignoreWhitespace: self.options.whitespace
+      ignoreWhitespace: self.options.whitespace,
+      skipRegenerate: self.options.skipRegenerate
     });
 
     // Mirror the adapter log method on the generator.

--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -150,9 +150,6 @@ class Conflicter {
     let contents = file.contents;
     const filepath = path.resolve(file.path);
 
-    // If file is new, then it's safe to process
-    if (!fs.existsSync(filepath)) return false;
-
     // If file path point to a directory, then it's not safe to write
     if (fs.statSync(filepath).isDirectory()) return true;
 
@@ -207,6 +204,11 @@ class Conflicter {
 
     if (!fs.existsSync(file.path)) {
       this.adapter.log.create(rfilepath);
+      if (this.bail) {
+        this.adapter.log.writeln('Aborting ...');
+        throw new ConflictError();
+      }
+
       cb('create');
       return;
     }

--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -53,7 +53,8 @@ class Conflicter {
     if (this.bail) {
       // Set ignoreWhitespace as true by default for bail.
       // Probably just testing, so don't override.
-      _.defaults(this, { ignoreWhitespace: true, skipRegenerate: true });
+      this.ignoreWhitespace = true;
+      this.skipRegenerate = true;
     }
   }
 

--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const async = require('async');
-const detectConflict = require('detect-conflict');
+const jsdiff = require('diff');
 const _ = require('lodash');
 const typedError = require('error/typed');
 const binaryDiff = require('./binary-diff');
@@ -35,11 +35,24 @@ const ConflictError = typedError({
  *                           testing reproducibility)
  */
 class Conflicter {
-  constructor(adapter, force, bail = false) {
+  constructor(adapter, force, options = {}) {
+    if (typeof options === 'boolean') {
+      this.bail = options;
+    } else {
+      this.bail = options.bail;
+      this.ignoreWhitespace = options.ignoreWhitespace;
+    }
+
     this.force = force === true;
-    this.bail = bail === true;
     this.adapter = adapter;
     this.conflicts = [];
+
+    this.diffOptions = options.diffOptions;
+
+    if (this.bail) {
+      // Set ignoreWhitespace as true by default for bail.
+      _.defaults(this, { ignoreWhitespace: true });
+    }
   }
 
   /**
@@ -104,12 +117,73 @@ class Conflicter {
    * @param  {Object}   file File object respecting this interface: { path, contents }
    */
   _printDiff(file) {
-    if (binaryDiff.isBinary(file.path, file.contents)) {
+    if (file.binary === undefined) {
+      file.binary = binaryDiff.isBinary(file.path, file.contents);
+    }
+
+    if (file.binary) {
       this.adapter.log.writeln(binaryDiff.diff(file.path, file.contents));
     } else {
       const existing = fs.readFileSync(file.path);
-      this.adapter.diff(existing.toString(), (file.contents || '').toString());
+      this.adapter.diff(
+        existing.toString(),
+        (file.contents || '').toString(),
+        file.changes
+      );
     }
+  }
+
+  /**
+   * Detect conflicts between file contents at `filepath` with the `contents` passed to the
+   * function
+   *
+   * If `filepath` points to a folder, we'll always return true.
+   *
+   * Based on detect-conflict module
+   *
+   * @param  {Object}   file File object respecting this interface: { path, contents }
+   * @return {Boolean} `true` if there's a conflict, `false` otherwise.
+   */
+  _detectConflict(file) {
+    let contents = file.contents;
+    const filepath = path.resolve(file.path);
+
+    // If file is new, then it's safe to process
+    if (!fs.existsSync(filepath)) return false;
+
+    // If file path point to a directory, then it's not safe to write
+    if (fs.statSync(filepath).isDirectory()) return true;
+
+    if (file.binary === undefined) {
+      file.binary = binaryDiff.isBinary(file.path, file.contents);
+    }
+
+    const actual = fs.readFileSync(path.resolve(filepath));
+
+    if (!(contents instanceof Buffer)) {
+      contents = Buffer.from(contents || '', 'utf8');
+    }
+
+    if (file.binary) {
+      return actual.toString('hex') !== contents.toString('hex');
+    }
+
+    if (this.ignoreWhitespace) {
+      file.changes = jsdiff.diffWords(
+        actual.toString(),
+        contents.toString(),
+        this.diffOptions
+      );
+    } else {
+      file.changes = jsdiff.diffLines(
+        actual.toString(),
+        contents.toString(),
+        this.diffOptions
+      );
+    }
+
+    const changes = file.changes;
+    return changes.length > 1 || changes[0].added || changes[0].removed;
   }
 
   /**
@@ -141,7 +215,7 @@ class Conflicter {
       return;
     }
 
-    if (detectConflict(file.path, file.contents)) {
+    if (this._detectConflict(file)) {
       this.adapter.log.conflict(rfilepath);
       if (this.bail) {
         this._printDiff(file);

--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -41,6 +41,7 @@ class Conflicter {
     } else {
       this.bail = options.bail;
       this.ignoreWhitespace = options.ignoreWhitespace;
+      this.skipRegenerate = options.skipRegenerate;
     }
 
     this.force = force === true;
@@ -51,7 +52,8 @@ class Conflicter {
 
     if (this.bail) {
       // Set ignoreWhitespace as true by default for bail.
-      _.defaults(this, { ignoreWhitespace: true });
+      // Probably just testing, so don't override.
+      _.defaults(this, { ignoreWhitespace: true, skipRegenerate: true });
     }
   }
 
@@ -226,7 +228,11 @@ class Conflicter {
       this._ask(file, cb);
     } else {
       this.adapter.log.identical(rfilepath);
-      cb('identical');
+      if (this.skipRegenerate) {
+        cb('skip');
+      } else {
+        cb('identical');
+      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1281,12 +1281,13 @@
     "detect-conflict": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
-      "integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
+      "integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24=",
+      "dev": true
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
     },
     "dir-glob": {
       "version": "2.0.0",
@@ -4052,6 +4053,12 @@
             "ms": "^2.1.1"
           }
         },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
         "glob": {
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -5278,6 +5285,12 @@
         "supports-color": "^5.5.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -6413,6 +6426,11 @@
             "ms": "^2.1.1"
           }
         },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -6745,6 +6763,14 @@
             "nise": "^1.3.3",
             "supports-color": "^5.4.0",
             "type-detect": "^4.0.8"
+          },
+          "dependencies": {
+            "diff": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+              "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+              "dev": true
+            }
           }
         },
         "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "dargs": "^6.1.0",
     "dateformat": "^3.0.3",
     "debug": "^4.1.1",
-    "detect-conflict": "^1.0.0",
+    "diff": "^4.0.1",
     "error": "^7.0.2",
     "find-up": "^3.0.0",
     "github-username": "^3.0.0",

--- a/test/conflicter.js
+++ b/test/conflicter.js
@@ -115,9 +115,9 @@ describe('Conflicter', () => {
     });
 
     it('abort on first conflict', function(done) {
-      this.conflicter.bail = true;
+      const conflicter = new Conflicter(new TestAdapter(), false, true);
       assert.throws(
-        this.conflicter.collision.bind(this.conflicter, this.conflictingFile),
+        conflicter.collision.bind(conflicter, this.conflictingFile),
         /^ConflicterConflictError: Process aborted by conflict$/
       );
       done();

--- a/test/conflicter.js
+++ b/test/conflicter.js
@@ -141,6 +141,20 @@ describe('Conflicter', () => {
       );
     });
 
+    it('abort on create new file', function(done) {
+      const conflicter = new Conflicter(new TestAdapter(), false, {
+        bail: true
+      });
+      assert.throws(
+        conflicter.collision.bind(conflicter, {
+          path: 'file-who-does-not-exist2.js',
+          contents: ''
+        }),
+        /^ConflicterConflictError: Process aborted by conflict$/
+      );
+      done();
+    });
+
     it('does not give a conflict with ignoreWhitespace', function(done) {
       const conflicter = new Conflicter(new TestAdapter(), false, {
         ignoreWhitespace: true

--- a/test/conflicter.js
+++ b/test/conflicter.js
@@ -123,6 +123,42 @@ describe('Conflicter', () => {
       done();
     });
 
+    it('does not give a conflict with ignoreWhitespace', function(done) {
+      const conflicter = new Conflicter(new TestAdapter(), false, {
+        ignoreWhitespace: true
+      });
+
+      conflicter.collision(
+        {
+          path: path.join(__dirname, 'fixtures/file-conflict.txt'),
+          contents: `initial
+           content
+`
+        },
+        status => {
+          assert.equal(status, 'identical');
+          done();
+        }
+      );
+    });
+
+    it('does give a conflict without ignoreWhitespace', function(done) {
+      const conflicter = new Conflicter(new TestAdapter({ action: 'skip' }));
+
+      conflicter.collision(
+        {
+          path: path.join(__dirname, 'fixtures/file-conflict.txt'),
+          contents: `initial
+           content
+`
+        },
+        status => {
+          assert.equal(status, 'skip');
+          done();
+        }
+      );
+    });
+
     it('does not give a conflict on same binary files', function(done) {
       this.conflicter.collision(
         {

--- a/test/conflicter.js
+++ b/test/conflicter.js
@@ -123,6 +123,24 @@ describe('Conflicter', () => {
       done();
     });
 
+    it('abort on first conflict with whitespace changes', function(done) {
+      const conflicter = new Conflicter(new TestAdapter(), false, {
+        bail: true
+      });
+      conflicter.collision(
+        {
+          path: path.join(__dirname, 'fixtures/file-conflict.txt'),
+          contents: `initial
+                 content
+      `
+        },
+        status => {
+          assert.equal(status, 'skip');
+          done();
+        }
+      );
+    });
+
     it('does not give a conflict with ignoreWhitespace', function(done) {
       const conflicter = new Conflicter(new TestAdapter(), false, {
         ignoreWhitespace: true
@@ -137,6 +155,26 @@ describe('Conflicter', () => {
         },
         status => {
           assert.equal(status, 'identical');
+          done();
+        }
+      );
+    });
+
+    it('skip rewrite with ignoreWhitespace and skipRegenerate', function(done) {
+      const conflicter = new Conflicter(new TestAdapter(), false, {
+        ignoreWhitespace: true,
+        skipRegenerate: true
+      });
+
+      conflicter.collision(
+        {
+          path: path.join(__dirname, 'fixtures/file-conflict.txt'),
+          contents: `initial
+           content
+`
+        },
+        status => {
+          assert.equal(status, 'skip');
           done();
         }
       );


### PR DESCRIPTION
- Reimplement detect-conflict inline to make it easier to change.
- Add ignore whitespace comparison.
- Add skipRegeneration option to don't override files with whitespace changes.