### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 15 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+        days-before-stale: 15
+        days-before-close: 5
+        stale-issue-label: 'stale'
+        exempt-issue-label: 'in progress'


### PR DESCRIPTION
File adds a workflow to GitHub actions that:

Once a day:
- add 'stale' tag to issues without activity for 15 days.
- close issues with 'stale' tag without activity for 5 days.

Since there are too few PR, I didn't add configuration for them.
And current stale actions doesn't have support for multiples tags.