### PR TITLE
Implement #composedCall

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ const ENV_VER_WITH_VER_API = '3.0.0';
 
 // Ensure a prototype method is a candidate run by default
 const methodIsValid = function(name) {
-  return name.charAt(0) !== '_' && name !== 'constructor' && !name.endsWith('#');
+  return name.charAt(0) !== '_' && name !== 'constructor' && !name.charAt(0) !== '#';
 };
 
 // New runWithOptions should take precedence if exists.
@@ -727,7 +727,6 @@ class Generator extends EventEmitter {
     assert(task.taskName);
     assert(task.method);
     const reject = task.reject;
-    const reject = task.reject || (() => {});
     const queueName = task.queueName || 'default';
     const methodName = task.taskName;
     const method = task.method;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ const minimist = require('minimist');
 const runAsync = require('run-async');
 const through = require('through2');
 const createDebug = require('debug');
+const { requireNamespace } = require('yeoman-environment/lib/namespace');
 
 const Conflicter = require('./util/conflicter');
 const Storage = require('./util/storage');
@@ -25,7 +26,7 @@ const ENV_VER_WITH_VER_API = '3.0.0';
 
 // Ensure a prototype method is a candidate run by default
 const methodIsValid = function(name) {
-  return name.charAt(0) !== '_' && name !== 'constructor';
+  return name.charAt(0) !== '_' && name !== 'constructor' && !name.endsWith('#');
 };
 
 // New runWithOptions should take precedence if exists.
@@ -813,8 +814,8 @@ class Generator extends EventEmitter {
     }
 
     if (property.get) {
-      this.queueGroupTask(property.get.call(self));
-      return;
+      this.queueTaskGroup(property.get.call(this));
+      return undefined;
     }
 
     const method = property.value;
@@ -826,9 +827,7 @@ class Generator extends EventEmitter {
 
     const tasks = method.call(this, ...parameters);
     if (typeof tasks !== 'object') {
-      throw new Error(
-        `Function ${name} is not a composed method at ${this.options.namespace}`
-      );
+      return tasks;
     }
 
     const self = this;
@@ -856,11 +855,12 @@ class Generator extends EventEmitter {
 
     if (Array.isArray(tasks)) {
       tasks.filter(task => task.method && task.taskName).forEach(queueTask);
-      return;
+      return undefined;
     }
 
     tasks.taskName = tasks.taskName || name;
     queueTask(tasks);
+    return undefined;
   }
 
   /**
@@ -994,6 +994,20 @@ class Generator extends EventEmitter {
     }
 
     return promise;
+  }
+
+  composeWithMethod(namespace, options, ...parameters) {
+    const namespaceObj = requireNamespace(namespace);
+    if (namespaceObj && namespaceObj.method) {
+      debug(`Running composed call ${namespaceObj}`);
+      let generator = this.env.getGeneratorInstance(namespaceObj);
+      if (!generator && options !== false) {
+        generator = this.env.create(namespaceObj, { ...options });
+      }
+
+      generator.runComposedMethod(namespaceObj.methodName, ...parameters);
+      return generator;
+    }
   }
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -692,12 +692,26 @@ class Generator extends EventEmitter {
   queueTaskGroup(taskGroup, taskOptions) {
     const self = this;
     // Run each queue items
-    _.each(taskGroup, (newMethod, newMethodName) => {
-      if (!_.isFunction(newMethod) || !methodIsValid(newMethodName)) return;
+    _.each(taskGroup, (groupMember, newMethodName) => {
+      if (typeof groupMember !== 'function') {
+        if (typeof groupMember === 'object') {
+          self.queueTask({
+            taskName: newMethodName,
+            ...groupMember,
+            ...taskOptions
+          });
+        }
+
+        return;
+      }
+
+      if (!methodIsValid(newMethodName)) {
+        return;
+      }
 
       self.queueTask({
         ...taskOptions,
-        method: newMethod,
+        method: groupMember,
         taskName: newMethodName
       });
     });
@@ -709,7 +723,10 @@ class Generator extends EventEmitter {
    * @param {Task} task: Task to be queued.
    */
   queueTask(task) {
+    assert(task.taskName);
+    assert(task.method);
     const reject = task.reject;
+    const reject = task.reject || (() => {});
     const queueName = task.queueName || 'default';
     const methodName = task.taskName;
     const method = task.method;
@@ -787,6 +804,63 @@ class Generator extends EventEmitter {
       },
       { once, run: task.run }
     );
+  }
+
+  runComposedMethod(name, ...parameters) {
+    const property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this), name);
+    if (!property) {
+      throw new Error(`Property ${name} not found at ${this.options.namespace}`);
+    }
+
+    if (property.get) {
+      this.queueGroupTask(property.get.call(self));
+      return;
+    }
+
+    const method = property.value;
+    if (typeof method !== 'function') {
+      throw new Error(
+        `Property ${name} is not a composed method at ${this.options.namespace}`
+      );
+    }
+
+    const tasks = method.call(this, ...parameters);
+    if (typeof tasks !== 'object') {
+      throw new Error(
+        `Function ${name} is not a composed method at ${this.options.namespace}`
+      );
+    }
+
+    const self = this;
+    const queueTask = function(task) {
+      if (!task.method) {
+        throw new Error(
+          `Invalid task at composed method ${name} at ${self.options.namespace}`
+        );
+      }
+
+      if (task.priorityName) {
+        const priority = self._queues[task.priorityName];
+        if (!priority) {
+          throw new Error(`Priority ${task.priorityName} is not defined`);
+        }
+
+        // If priority is defined, use it configs as defaults;
+        task = { ...priority, ...task };
+      }
+
+      // If run in not defined, set to false to don't start the loop if not running yet
+      task.run = task.run === undefined ? false : task.run;
+      self.queueTask(task);
+    };
+
+    if (Array.isArray(tasks)) {
+      tasks.filter(task => task.method && task.taskName).forEach(queueTask);
+      return;
+    }
+
+    tasks.taskName = tasks.taskName || name;
+    queueTask(tasks);
   }
 
   /**


### PR DESCRIPTION
Allows to queue a method or step from another generator.
To create a method that should be exclusive to composed call, you can
test for options:

```
function(options) {
  if (!options || !options.composedCall) {
    return;
  }
}
```

Depends on https://github.com/yeoman/environment/pull/131