### PR TITLE
Emit error instead of throwing it.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -477,10 +477,12 @@ class Generator extends EventEmitter {
 
       const methods = Object.getOwnPropertyNames(Object.getPrototypeOf(this));
       const validMethods = methods.filter(methodIsValid);
-      assert(
-        validMethods.length,
-        'This Generator is empty. Add at least one method for it to run.'
-      );
+      if (!validMethods.length) {
+        this.emit(
+          'error',
+          new Error('This Generator is empty. Add at least one method for it to run.')
+        );
+      }
 
       this.env.runLoop.once('end', () => {
         this.emit('end');


### PR DESCRIPTION
The error is thrown outside the runLoop, so it's not properly emitted.