### PR TITLE
Implement localConfigOnly option, to reduce unwanted outside

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -159,20 +159,24 @@ class Generator extends EventEmitter {
     // Determine the app root
     this.contextRoot = this.env.cwd;
 
-    let rootPath = findUp.sync('.yo-rc.json', {
-      cwd: this.env.cwd
-    });
-    rootPath = rootPath ? path.dirname(rootPath) : this.env.cwd;
+    if (this.options.localConfigOnly) {
+      debug('Using local configurations only');
+    } else {
+      let rootPath = findUp.sync('.yo-rc.json', {
+        cwd: this.env.cwd
+      });
+      rootPath = rootPath ? path.dirname(rootPath) : this.env.cwd;
 
-    if (rootPath !== this.env.cwd) {
-      this.log(
-        [
-          '',
-          'Just found a `.yo-rc.json` in a parent directory.',
-          'Setting the project root at: ' + rootPath
-        ].join('\n')
-      );
-      this.destinationRoot(rootPath);
+      if (rootPath !== this.env.cwd) {
+        this.log(
+          [
+            '',
+            'Just found a `.yo-rc.json` in a parent directory.',
+            'Setting the project root at: ' + rootPath
+          ].join('\n')
+        );
+        this.destinationRoot(rootPath);
+      }
     }
 
     this.appname = this.determineAppname();
@@ -801,7 +805,11 @@ class Generator extends EventEmitter {
    * @private
    */
   _getGlobalStorage() {
-    const storePath = path.join(os.homedir(), '.yo-rc-global.json');
+    // When localConfigOnly === true simulate a globalConfig at local dir
+    const globalStorageDir = this.options.localConfigOnly
+      ? this.destinationRoot()
+      : os.homedir();
+    const storePath = path.join(globalStorageDir, '.yo-rc-global.json');
     const storeName = `${this.rootGeneratorName()}:${this.rootGeneratorVersion()}`;
     return new Storage(storeName, this.fs, storePath);
   }

--- a/test/generators.js
+++ b/test/generators.js
@@ -2,12 +2,18 @@
 const EventEmitter = require('events');
 const Environment = require('yeoman-environment');
 const assert = require('yeoman-assert');
+const path = require('path');
+const os = require('os');
+
 const Base = require('..');
 
 describe('Generators module', () => {
+  beforeEach(function() {
+    this.env = Environment.createEnv();
+  });
+
   describe('Base', () => {
     beforeEach(function() {
-      this.env = Environment.createEnv();
       this.generator = new Base({
         env: this.env,
         resolved: 'test'
@@ -21,5 +27,28 @@ describe('Generators module', () => {
       this.generator.on('yay-o-man', done);
       this.generator.emit('yay-o-man');
     });
+  });
+
+  it('without localConfigOnly option', function() {
+    this.generator = new Base({
+      env: this.env,
+      resolved: 'test'
+    });
+    assert.equal(
+      path.join(os.homedir(), '.yo-rc-global.json'),
+      this.generator._globalConfig.path
+    );
+  });
+
+  it('with localConfigOnly option', function() {
+    this.generator = new Base({
+      env: this.env,
+      resolved: 'test',
+      localConfigOnly: true
+    });
+    assert.equal(
+      path.join(this.env.cwd, '.yo-rc-global.json'),
+      this.generator._globalConfig.path
+    );
   });
 });


### PR DESCRIPTION
interference.

- Don't look for .yo-rc.json at parent folders.
- Simulate global config at current folder.

Fixes https://github.com/yeoman/generator/issues/1094