### PR TITLE
Bump shelljs to 0.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5250,9 +5250,9 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shelljs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
       "requires": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "rimraf": "^2.6.3",
     "run-async": "^2.0.0",
     "semver": "^7.2.1",
-    "shelljs": "^0.8.3",
+    "shelljs": "^0.8.4",
     "text-table": "^0.2.0",
     "through2": "^3.0.1"
   },


### PR DESCRIPTION
v0.8.4 included a commit to prevent circular dependency warnings in Node 14.

See also: https://github.com/shelljs/shelljs/pull/973