### PR TITLE
Update description of prompt

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -502,13 +502,13 @@ class Generator extends EventEmitter {
   /**
    * Prompt user to answer questions. The signature of this method is the same as {@link https://github.com/SBoudrias/Inquirer.js Inquirer.js}
    *
-   * On top of the Inquirer.js API, you can provide a `{cache: true}` property for
+   * On top of the Inquirer.js API, you can provide a `{store: true}` property for
    * every question descriptor. When set to true, Yeoman will store/fetch the
    * user's answers as defaults.
    *
    * @param  {object|object[]} questions  Array of question descriptor objects. See {@link https://github.com/SBoudrias/Inquirer.js/blob/master/README.md Documentation}
-   * @param  {Storage} [questions.storage] Store/fetch the question on the storage.
-   * @param  {Storage} [storage] Storage object
+   * @param  {Storage|String} [questions.storage] Store/fetch the question on the storage.
+   * @param  {Storage|String} Storage fallback if question does not provide.  String is property name of Generator type Storage
    * @return {Promise} prompt promise
    */
   prompt(questions, storage) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -507,8 +507,8 @@ class Generator extends EventEmitter {
    * user's answers as defaults.
    *
    * @param  {object|object[]} questions  Array of question descriptor objects. See {@link https://github.com/SBoudrias/Inquirer.js/blob/master/README.md Documentation}
-   * @param  {Storage|String} [questions.storage] Store/fetch the question on the storage.
-   * @param  {Storage|String} Storage fallback if question does not provide.  String is property name of Generator type Storage
+   * @param  {Storage|String} [questions.storage] Storage object or name (generator property) to be used by the question to store/fetch the response.
+   * @param  {Storage|String} [storage] Storage object or name (generator property) to be used by default to store/fetch responses.
    * @return {Promise} prompt promise
    */
   prompt(questions, storage) {


### PR DESCRIPTION
Correct cache to store.
Add that storage property can be specified as a string.
Add that storage parameter is a fallback storage.