### PR TITLE
Implement taskPrefix feature.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ const Base = mixins.reduce((a, b) => b(a), EventEmitter);
 
 // Ensure a prototype method is a candidate run by default
 const methodIsValid = function (name) {
-  return !['_', '#'].includes(name.charAt(0)) && name !== 'constructor';
+  return name.charAt(0) !== '_' && name !== 'constructor';
 };
 
 /**
@@ -123,6 +123,7 @@ class Generator extends Base {
    *                                    The Environment will ignore duplicated identifiers.
    * @property {String}   unique      - uniqueBy calculation method (undefined/argument/namespace)
    * @property {boolean} tasksMatchingPriority - Only queue methods that matches a priority.
+   * @property {String}   taskPrefix  - Tasks methods starts with prefix. Allows api methods (non tasks) without prefix.
    * @property {boolean|Function} customInstallTask - Provides a custom install task. Environment >= 3.2.0
    *                                                  Environment built-in task will not be executed
    * @property {boolean|Function} customCommitTask - Provides a custom commit task. Environment >= 3.2.0
@@ -875,9 +876,11 @@ class Generator extends Base {
    * @param {TaskOptions} [taskOptions]: options.
    */
   queueOwnTask(name, taskOptions = {}) {
+    const {taskPrefix} = this.features;
+    const propertyName = taskPrefix ? `${taskPrefix}${name}` : name;
     const property = Object.getOwnPropertyDescriptor(
       Object.getPrototypeOf(this),
-      name
+      propertyName
     );
     const item = property.value ? property.value : property.get.call(this);
 
@@ -914,6 +917,15 @@ class Generator extends Base {
   getTaskNames() {
     const methods = Object.getOwnPropertyNames(Object.getPrototypeOf(this));
     let validMethods = methods.filter(methodIsValid);
+    const {taskPrefix} = this.features;
+
+    if (taskPrefix) {
+      validMethods = validMethods
+        .filter((method) => method.startsWith(taskPrefix))
+        .map((method) => method.slice(taskPrefix.length));
+    } else {
+      validMethods = validMethods.filter((method) => method.charAt(0) !== '#');
+    }
 
     if (this.features.tasksMatchingPriority) {
       const queueNames = Object.keys(this._queues);

--- a/test/base.js
+++ b/test/base.js
@@ -550,6 +550,39 @@ describe('Base', () => {
     });
   });
 
+  describe('#run() with', () => {
+    beforeEach(function () {
+      this.TestGenerator = class extends Base {};
+      _.extend(this.TestGenerator.prototype, {
+        _private: sinon.spy(),
+        '#composed': sinon.spy(),
+        composed: sinon.spy(),
+        '#initializing': sinon.spy(),
+        initializing: sinon.spy()
+      });
+
+      this.testGen = new this.TestGenerator(
+        [],
+        {
+          resolved: 'generator-ember/all/index.js',
+          namespace: 'dummy',
+          env: this.env,
+          'skip-install': true
+        },
+        {taskPrefix: '#'}
+      );
+    });
+
+    it('should run hashtag prefixed method', async function () {
+      await this.testGen.run();
+      assert(this.TestGenerator.prototype['#composed'].calledOnce);
+      assert(this.TestGenerator.prototype.composed.notCalled);
+      assert(this.TestGenerator.prototype['#initializing'].calledOnce);
+      assert(this.TestGenerator.prototype.initializing.notCalled);
+      assert(this.TestGenerator.prototype._private.notCalled);
+    });
+  });
+
   describe('#argument()', () => {
     it('add a new argument to the generator instance', function () {
       assert.equal(this.dummy._arguments.length, 0);


### PR DESCRIPTION
Allows tasks to have a prefix, methods can be treated as normal api.