### PR TITLE
Add before queue callback and composeWith immediately.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1163,7 +1163,9 @@ class Generator extends Base {
   /**
    * Compose this generator with another one.
    * @param  {String|Object|Array} generator  The path to the generator module or an object (see examples)
+   * @param  {Array}  [args]       Arguments passed to the Generator
    * @param  {Object}  [options]   The options passed to the Generator
+   * @param  {boolean}  [immediately] Boolean whether to queue the Generator immediately
    * @return {Generator}    The composed generator
    *
    * @example <caption>Using a peerDependency generator</caption>
@@ -1175,7 +1177,7 @@ class Generator extends Base {
    * @example <caption>Passing a Generator class</caption>
    * this.composeWith({ Generator: MyGenerator, path: '../generator-bootstrap/app/main.js' }, { sass: true });
    */
-  composeWith(generator, args, options) {
+  composeWith(generator, args, options, immediately = false) {
     if (typeof args === 'boolean') {
       args = [];
     } else if (!Array.isArray(args) && typeof args === 'object') {
@@ -1263,7 +1265,7 @@ this.composeWith({
       return instantiatedGenerator;
     }
 
-    if (this._running) {
+    if (this._running || immediately) {
       this.env.queueGenerator(instantiatedGenerator);
     } else {
       this._composedWith.push(instantiatedGenerator);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1120,14 +1120,44 @@ class Generator extends Base {
     return this.env.runGenerator(this);
   }
 
+  /**
+   * Queue generator tasks.
+   *
+   * @return {Promise}
+   */
   queueTasks() {
+    const beforeQueueCallback =
+      (this.features.taskPrefix && this.beforeQueue) || this._beforeQueue;
+    if (beforeQueueCallback) {
+      const maybePromise = beforeQueueCallback.call(this);
+      if (maybePromise && maybePromise.then) {
+        this.checkEnvironmentVersion('3.5.0');
+        return maybePromise.then(() => this._queueTasks());
+      }
+    }
+
+    return this._queueTasks();
+  }
+
+  _queueTasks() {
     debug(
       `Queueing generator ${this.options.namespace} with generator version ${this.yoGeneratorVersion}`
     );
     this.queueOwnTasks();
-    for (const generator of this._composedWith)
-      this.env.queueGenerator(generator, false);
+    let promise;
+    for (const generator of this._composedWith) {
+      if (promise) {
+        promise.then(() => this.env.queueGenerator(generator, false));
+      } else {
+        const maybePromise = this.env.queueGenerator(generator, false);
+        if (maybePromise.then) {
+          promise = maybePromise;
+        }
+      }
+    }
+
     this._composedWith = [];
+    return promise;
   }
 
   /**

--- a/test/base.js
+++ b/test/base.js
@@ -886,10 +886,19 @@ describe('Base', () => {
       this.env.registerStub(this.GenCompose, 'composed:gen');
     });
 
-    it('returns the composed generator when pass true', function () {
-      assert(
-        this.dummy.composeWith('composed:gen', true) instanceof this.GenCompose
-      );
+    it('returns the composed generator', function () {
+      assert(this.dummy.composeWith('composed:gen') instanceof this.GenCompose);
+    });
+
+    it('should add to _composedWith', function () {
+      const generator = this.dummy.composeWith('composed:gen');
+      assert(generator instanceof this.GenCompose);
+      assert(generator === this.dummy._composedWith[0]);
+    });
+
+    it('should not add to _composedWith when immediately is true', function () {
+      this.dummy.composeWith('composed:gen', undefined, undefined, true);
+      assert.strictEqual(this.dummy._composedWith.length, 0);
     });
 
     it('runs the composed generators', function (done) {

--- a/test/base.js
+++ b/test/base.js
@@ -212,6 +212,7 @@ describe('Base', () => {
     beforeEach(function () {
       this.TestGenerator = class extends Base {};
       _.extend(this.TestGenerator.prototype, {
+        _beforeQueue: sinon.spy(),
         exec: sinon.spy(),
         exec2: sinon.spy(),
         exec3: sinon.spy(),
@@ -242,6 +243,11 @@ describe('Base', () => {
     it('turn on _running flag', function () {
       this.testGen.queueTasks();
       assert.ok(this.testGen._running);
+    });
+
+    it('should call _beforeQueue', function () {
+      this.testGen.queueTasks();
+      assert.ok(this.testGen._beforeQueue.calledOnce);
     });
 
     it('run prototype methods (not instances one)', function () {
@@ -550,10 +556,11 @@ describe('Base', () => {
     });
   });
 
-  describe('#run() with', () => {
+  describe('#run() with task prefix', () => {
     beforeEach(function () {
       this.TestGenerator = class extends Base {};
       _.extend(this.TestGenerator.prototype, {
+        beforeQueue: sinon.spy(),
         _private: sinon.spy(),
         '#composed': sinon.spy(),
         composed: sinon.spy(),
@@ -580,6 +587,11 @@ describe('Base', () => {
       assert(this.TestGenerator.prototype['#initializing'].calledOnce);
       assert(this.TestGenerator.prototype.initializing.notCalled);
       assert(this.TestGenerator.prototype._private.notCalled);
+    });
+
+    it('should call beforeQueue', function () {
+      this.testGen.queueTasks();
+      assert.ok(this.testGen.beforeQueue.calledOnce);
     });
   });
 


### PR DESCRIPTION
Allows composing with another generator, with the composed generator been queued before current one.
An async before queue callback generates an async composeWith().