### PR TITLE
Bump version of shelljs to avoid vulnerable 0.8.4 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "read-pkg-up": "^7.0.1",
         "run-async": "^2.0.0",
         "semver": "^7.2.1",
-        "shelljs": "^0.8.4",
+        "shelljs": "^0.8.5",
         "sort-keys": "^4.2.0",
         "text-table": "^0.2.0"
       },
@@ -10718,9 +10718,9 @@
       }
     },
     "node_modules/shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -22459,9 +22459,9 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "requires": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -24216,8 +24216,6 @@
         "is-scoped": "^2.1.0",
         "lodash": "^4.17.10",
         "log-symbols": "^4.0.0",
-        "mem-fs": "^1.2.0 || ^2.0.0",
-        "mem-fs-editor": "^8.1.2 || ^9.0.0",
         "minimatch": "^3.0.4",
         "npmlog": "^4.1.2",
         "p-queue": "^6.6.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "read-pkg-up": "^7.0.1",
     "run-async": "^2.0.0",
     "semver": "^7.2.1",
-    "shelljs": "^0.8.4",
+    "shelljs": "^0.8.5",
     "sort-keys": "^4.2.0",
     "text-table": "^0.2.0"
   },


### PR DESCRIPTION
Snyk has identified a vulnerably dependency `shelljs` in this repository - Can see details here: https://snyk.io/vuln/npm:shelljs

This PR simply bumps the shelljs version from 0.8.4 to 0.8.5 resolving that vulnerability.