### PR TITLE
Synchronize the Environment's `cwd` with the Destination Root

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -733,7 +733,7 @@ export class BaseGenerator<O extends BaseOptions = BaseOptions, F extends BaseFe
    * @param rootPath new destination root path
    * @return destination root path
    */
-  destinationRoot(rootPath?: string) {
+  destinationRoot(rootPath?: string, updateEnvironment = false) {
     if (typeof rootPath === 'string') {
       this._destinationRoot = pathResolve(rootPath);
 
@@ -746,8 +746,11 @@ export class BaseGenerator<O extends BaseOptions = BaseOptions, F extends BaseFe
       this._config = undefined;
       // Reset packageJson
       this._packageJson = undefined;
-      // Sync environment cwd
-      this.env.cwd = rootPath;
+
+      if (updateEnvironment) {
+        // Sync environment cwd
+        this.env.cwd = rootPath;
+      }
     }
 
     return this._destinationRoot || this.env.cwd;

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -746,6 +746,8 @@ export class BaseGenerator<O extends BaseOptions = BaseOptions, F extends BaseFe
       this._config = undefined;
       // Reset packageJson
       this._packageJson = undefined;
+      // Sync environment cwd
+      this.env.cwd = rootPath;
     }
 
     return this._destinationRoot || this.env.cwd;

--- a/test/generators.js
+++ b/test/generators.js
@@ -129,7 +129,10 @@ describe('Generators module', () => {
 
     it('should change env cwd', function () {
       const path = tmpdir();
+      const oldPath = this.env.cwd;
       this.generator.destinationRoot(path);
+      assert.strictEqual(this.env.cwd, oldPath);
+      this.generator.destinationRoot(path, true);
       assert.strictEqual(this.env.cwd, path);
     });
   });

--- a/test/generators.js
+++ b/test/generators.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'node:events';
 import path from 'node:path';
-import os from 'node:os';
+import os, { tmpdir } from 'node:os';
 import Environment from 'yeoman-environment';
 import assert from 'yeoman-assert';
 import semver from 'semver';
@@ -108,6 +108,29 @@ describe('Generators module', () => {
       const customStorage = this.generator.createStorage(global);
       assert.equal(global, customStorage.path);
       assert.equal(undefined, customStorage.name);
+    });
+  });
+
+  describe('#destinationRoot', () => {
+    let currentCwd;
+    beforeEach(function () {
+      this.generator = new Base({
+        env: this.env,
+        resolved: 'test',
+        localConfigOnly: true,
+      });
+
+      currentCwd = this.env.cwd;
+    });
+
+    afterEach(function () {
+      this.env.cwd = currentCwd;
+    });
+
+    it('should change env cwd', function () {
+      const path = tmpdir();
+      this.generator.destinationRoot(path);
+      assert.strictEqual(this.env.cwd, path);
     });
   });
 


### PR DESCRIPTION
As mentioned in a few issues, the environment's cwd not changing causes `yo` to not automatically pick up changes in `package.json` and neither perform installation processes on its own.

Since the next release, as it looks, seems to be a good occasion to introduce this change.

Changes made in this PR will synchronize `Environment.cwd` (in `this.env.cwd`) whenever the destination root is changed through `Generator.destinationRoot` (by calling `this.destinationRoot()`).

This change will re-enable `yo` to automatically process installations even if the destination root is changed during the generator run loop.

This PR is related to...
  - Maybe
    - #1315 
    - #991
  - Definitely
    - yeoman/environment#319
    - yeoman/environment#309