### PR TITLE
Test cleanup: deprecate.test.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "yeoman-test": "^8.1.0"
       },
       "engines": {
-        "node": "^16.13.0 || >=18.12.0"
+        "node": "^18.17.0 || >=20.5.0"
       },
       "peerDependencies": {
         "@yeoman/types": "^1.1.1",

--- a/test/deprecate.test.ts
+++ b/test/deprecate.test.ts
@@ -10,12 +10,16 @@ type SimpleObject = {
 };
 
 describe('deprecate()', () => {
+  let fakeConsoleLog: SinonSpy;
   beforeEach(() => {
-    sinon.spy(console, 'log');
+    fakeConsoleLog = sinon.fake();
+    sinon.replace(console, 'log', fakeConsoleLog);
   });
 
   afterEach(() => {
-    console.log.restore();
+    sinon.restore();
+  });
+    sinon.restore();
   });
 
   it('log a message', () => {

--- a/test/deprecate.test.ts
+++ b/test/deprecate.test.ts
@@ -1,8 +1,13 @@
 /* eslint-disable import/no-named-as-default-member */
 import assert from 'node:assert';
 import chalk from 'chalk';
-import sinon from 'sinon';
+import sinon, { type SinonSpy } from 'sinon';
 import deprecate from '../src/util/deprecate.js';
+
+type SimpleObject = {
+  foo: number;
+  functionInObj: (someValue: number) => number;
+};
 
 describe('deprecate()', () => {
   beforeEach(() => {

--- a/test/deprecate.test.ts
+++ b/test/deprecate.test.ts
@@ -29,6 +29,11 @@ describe('deprecate()', () => {
     wrapped('bar', 2);
     sinon.assert.calledWith(console.log, chalk.yellow('(!) ') + 'foo');
     sinon.assert.calledWith(func, 'bar', 2);
+  describe('.log', () => {
+    it('logs the message in yellow, starting with "(!) "', () => {
+      deprecate.log('this is the message');
+      assert.ok(fakeConsoleLog.calledWith(chalk.yellow('(!) ') + 'this is the message'));
+    });
   });
 
   describe('.object()', () => {

--- a/test/deprecate.test.ts
+++ b/test/deprecate.test.ts
@@ -73,8 +73,6 @@ describe('deprecate()', () => {
       sinon.restore();
     });
 
-    // When deprecate.js is changed to .ts, DeprecatedObject will be defined in deprecate.ts as something like type DeprecatedObject<O> = O;
-
     it('deprecates all functions/methods in the object', () => {
       type SomeOtherObject = SimpleObject & {
         anotherFunction: (someValue: string) => string;
@@ -89,15 +87,16 @@ describe('deprecate()', () => {
         },
       };
 
+      // TODO When deprecate.js is changed to .ts, DeprecatedObject will be defined in deprecate.ts as something like type DeprecatedObject<O> = O;
       const deprecatedObject = deprecate.object('<%= name %> is deprecated', originalObject);
-      // @ts-expect-error This should be a DeprecatedObject<SimpleObject>. When deprecate.js is changed to .ts, this can be implemented and no error will occur here.
+      // @ts-expect-error  The method functionInObj() does exist on deprecatedObject. This should be a DeprecatedObject<SimpleObject>. When deprecate.js is changed to .ts, this can be implemented and no error will occur here.
       deprecatedObject.functionInObj(42);
       assert.ok(
         deprecatedLogSpy.calledWith('functionInObj is deprecated'),
         `last call with args: ${deprecatedLogSpy.lastCall.args[0]}`,
       );
 
-      // @ts-expect-error This should be a DeprecatedObject<SimpleObject>. When deprecate.js is changed to .ts, this can be implemented and no error will occur here.
+      // @ts-expect-error  The method anotherFunction() does exist on deprecatedObject. This should be a DeprecatedObject<SimpleObject>. When deprecate.js is changed to .ts, this can be implemented and no error will occur here.
       deprecatedObject.anotherFunction('something');
       assert.ok(
         deprecatedLogSpy.calledWith('anotherFunction is deprecated'),
@@ -114,7 +113,7 @@ describe('deprecate()', () => {
       };
 
       const deprecatedObject = deprecate.object('The function "<%= name %>" is deprecated', originalObject);
-      // @ts-expect-error This should be a DeprecatedObject<SimpleObject>. When deprecate.js is changed to .ts, this can be implemented and no error will occur here.
+      // @ts-expect-error  The property foo does exist on deprecatedObject. This should be a DeprecatedObject<SimpleObject>. When deprecate.js is changed to .ts, this can be implemented and no error will occur here.
       const fooValue = deprecatedObject.foo;
       assert.equal(fooValue, 1);
       assert.ok(deprecatedLogSpy.notCalled);
@@ -140,15 +139,15 @@ describe('deprecate()', () => {
       };
 
       const deprecatedObject = deprecate.object('The function "<%= name %>" is deprecated', originalObject);
-      // @ts-expect-error This should be a DeprecatedObject<SimpleObject>. When deprecate.js is changed to .ts, this can be implemented and no error will occur here.
+      // @ts-expect-error The getter bar does exist on the object. This should be a DeprecatedObject<SimpleObject>. When deprecate.js is changed to .ts, this can be implemented and no error will occur here.
       deprecatedObject.bar;
-      // @ts-expect-error This should be a DeprecatedObject<SimpleObject>. When deprecate.js is changed to .ts, this can be implemented and no error will occur here.
+      // @ts-expect-error The setter bar does exist on the object. This should be a DeprecatedObject<SimpleObject>. When deprecate.js is changed to .ts, this can be implemented and no error will occur here.
       deprecatedObject.bar = 7;
 
       assert.ok(deprecatedLogSpy.notCalled);
     });
 
-    it('message can be a template', () => {
+    it('deprecation message can be a template', () => {
       const originalObject: SimpleObject = {
         foo: 1,
         functionInObj(someValue: number): number {
@@ -158,7 +157,7 @@ describe('deprecate()', () => {
 
       const deprecatedObject = deprecate.object('The function "<%= name %>" is deprecated', originalObject);
 
-      // @ts-expect-error This should be a DeprecatedObject<SimpleObject>. When deprecate.js is changed to .ts, this can be implemented and no error will occur here.
+      // @ts-expect-error The method functionInObj() does exist on deprecatedObject. This should be a DeprecatedObject<SimpleObject>. When deprecate.js is changed to .ts, this can be implemented and no error will occur here.
       deprecatedObject.functionInObj(42);
 
       assert.ok(
@@ -180,13 +179,13 @@ describe('deprecate()', () => {
     });
 
     it('the deprecated message shows when a property is accessed', () => {
-      const originalObjectect = {
+      const originalObject = {
         foo: 1,
       };
-      deprecate.property('foo property is deprecated', originalObjectect, 'foo');
+      deprecate.property('foo property is deprecated', originalObject, 'foo');
 
       // Value is not affected; it remains the same
-      assert.equal(originalObjectect.foo, 1);
+      assert.equal(originalObject.foo, 1);
 
       assert.ok(
         deprecatedLogSpy.calledWith('foo property is deprecated'),

--- a/test/deprecate.test.ts
+++ b/test/deprecate.test.ts
@@ -19,16 +19,42 @@ describe('deprecate()', () => {
   afterEach(() => {
     sinon.restore();
   });
-    sinon.restore();
+
+  describe('deprecate a function', () => {
+    let deprecatedLogSpy: SinonSpy;
+    beforeEach(() => {
+      deprecatedLogSpy = sinon.fake();
+      sinon.replace(deprecate, 'log', deprecatedLogSpy);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('the original function is still called', () => {
+      const originalFunction = sinon.spy();
+      const deprecatedFunction = deprecate('this is function deprecated', originalFunction);
+
+      deprecatedFunction('baz', 3);
+      assert.ok(
+        originalFunction.calledWith('baz', 3),
+        `original function called with (${originalFunction.lastCall.args[0]}, ${originalFunction.lastCall.args[1]})`,
+      );
+    });
+
+    it('a call to deprecate.log(msg) is added', () => {
+      const originalFunction = sinon.spy();
+      const deprecatedFunction = deprecate('this is function deprecated', originalFunction);
+
+      originalFunction('bar', 2);
+      assert.ok(originalFunction.calledWith('bar', 2), 'original function not called with ("bar", 2)');
+      assert.ok(deprecatedLogSpy.notCalled);
+
+      deprecatedFunction('baz', 3);
+      assert.ok(deprecatedLogSpy.calledWith('this is function deprecated'));
+    });
   });
 
-  it('log a message', () => {
-    const func = sinon.spy();
-    const wrapped = deprecate('foo', func);
-    sinon.assert.notCalled(console.log);
-    wrapped('bar', 2);
-    sinon.assert.calledWith(console.log, chalk.yellow('(!) ') + 'foo');
-    sinon.assert.calledWith(func, 'bar', 2);
   describe('.log', () => {
     it('logs the message in yellow, starting with "(!) "', () => {
       deprecate.log('this is the message');


### PR DESCRIPTION
- added TODO for changing `deprecate.js` to `deprecate.ts` (as a reminder and to note which lines can be changed (improved) when that happends
- added types (SinonSpy, a type for the object used for testing)
- created separate tests for:
   - testing deprecated functions
   - testing deprecated objects
      - properties
      - functions
- change the word 'wrapped' so that it's clear what is happening (deprecation)

part of cleaning up tests #1481 