### PR TITLE
chore: Export questions types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import type { BaseFeatures, BaseOptions } from './types.js';
 import { DESTINATION_ROOT_CHANGE_EVENT } from './constants.js';
 
 export type * from './types.js';
+export type * from './questions.js';
 export type * from './util/storage.js';
 export { default as Storage } from './util/storage.js';
 


### PR DESCRIPTION
Exports types from `questions.d.ts`.

Fixes #1575 