### PR TITLE
chore: deprecate github/username utility

### DIFF
--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -47,7 +47,7 @@ export abstract class GitMixin {
   get github() {
     return {
       /**
-       * @deprecated Will be removed in version 8. Use 'github-username' package directly instead.
+       * @deprecated Will be removed in version 8. Use 'github-username' package with `await this.git.email()` result instead.
        *
        * Retrieves GitHub's username from the GitHub API
        * @return Resolved with the GitHub username or rejected if unable to

--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -40,9 +40,15 @@ export abstract class GitMixin {
     return this._git;
   }
 
+  /**
+   * @deprecated Will be removed in version 8.
+   * GitHub utilities.
+   */
   get github() {
     return {
       /**
+       * @deprecated Will be removed in version 8. Use 'github-username' package directly instead.
+       *
        * Retrieves GitHub's username from the GitHub API
        * @return Resolved with the GitHub username or rejected if unable to
        *                   get the information


### PR DESCRIPTION
<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/.github/blob/master/.github/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [ ] Enhancement
- [x] Other, please explain:

Deprecate GitHub/username utility.
This utility has very limited usefulness and it’s dependencies take at least a third of yeoman-generator install size.

## What changes did you make?

<!-- Give an overview -->

## Is there anything you'd like reviewers to focus on?

<!-- Just in case -->