### PR TITLE
feat: move `@types/node` to peer dependencies and make it optional.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/lodash-es": "^4.17.9",
-        "@types/node": ">=18.18.5",
         "@yeoman/namespace": "^1.0.0",
         "chalk": "^5.3.0",
         "debug": "^4.1.1",
@@ -57,8 +56,14 @@
         "node": "^18.17.0 || >=20.5.0"
       },
       "peerDependencies": {
+        "@types/node": ">=18.18.5",
         "@yeoman/types": "^1.1.1",
         "mem-fs": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@types/lodash-es": "^4.17.9",
-    "@types/node": ">=18.18.5",
     "@yeoman/namespace": "^1.0.0",
     "chalk": "^5.3.0",
     "debug": "^4.1.1",
@@ -96,8 +95,14 @@
     "yeoman-test": "^10.0.1"
   },
   "peerDependencies": {
+    "@types/node": ">=18.18.5",
     "@yeoman/types": "^1.1.1",
     "mem-fs": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/node": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "^18.17.0 || >=20.5.0"


### PR DESCRIPTION
<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/.github/blob/master/.github/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [ ] Enhancement
- [x] Other, please explain:

Move `@types/node` to peer dependencies and make it optional.
So it won't be pulled in prod installs.

`mem-fs-editor` needs the same fix.

## What changes did you make?

<!-- Give an overview -->

## Is there anything you'd like reviewers to focus on?

<!-- Just in case -->