### PR TITLE
Fix null being stored instead of null when using deep path

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -432,7 +432,7 @@ export class BaseGenerator<
     const answers = await this.env.adapter.prompt(questions, initialAnswers);
 
     for (const [name, questionStorage] of Object.entries(storageForQuestion)) {
-      const answer: any = answers[name] === undefined ? null : answers[name];
+      const answer: any = _.get(answers, name, null);
       questionStorage.setPath(name, answer);
     }
 


### PR DESCRIPTION
<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/.github/blob/master/.github/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [x] Bug fix 
- [ ] Enhancement
- [ ] Other, please explain:

## What changes did you make?

When using a question name containing a dot (like `foo.bar`) the answers are returned as keys in an object (`{ foo: { bar: 'answer' } }`), this means `answers[name]` will be undefined and `null` will be stored in storage instead of the correct answer.

This PR fix it by using lodash's `get` to get the correct value from the answers.
