### PR TITLE
fix: resolve `moveDestination` source against the destination root

### DIFF
--- a/src/actions/fs.ts
+++ b/src/actions/fs.ts
@@ -244,7 +244,7 @@ export class FsMixin {
     const [from, to, options, ...remaining] = args;
 
     return this.fs.move(
-      from,
+      this.destinationPath(from),
       this.destinationPath(to),
       { fromBasePath: this.destinationPath(), ...options },
       ...remaining,

--- a/test/fs.test.ts
+++ b/test/fs.test.ts
@@ -79,6 +79,7 @@ const testResults: FSOpResult[] = [
   },
   {
     name: 'moveDestination',
+    first: 'destinationPath',
     second: 'destinationPath',
     fromBasePath: 'destinationPath',
     dest: 'move',
@@ -626,6 +627,23 @@ describe('generators.Base (actions/fs)', () => {
       expect(copyTplAsync).toHaveBeenCalledTimes(0);
 
       expect(receivedData).toBe(templateData);
+    });
+  });
+  describe('#moveDestination (source deletion)', () => {
+    it('deletes the source relative to the destination root', () => {
+      const generator = new Base({ env: createEnv(), resolved: 'unknown', help: true });
+      const destinationRoot = path.join(process.cwd(), `move-destination-${randomString()}`);
+      const destinationRootStub = vi.spyOn(generator, 'destinationRoot').mockReturnValue(destinationRoot);
+
+      try {
+        generator.writeDestination('a.txt', 'foo');
+        generator.moveDestination('a.txt', 'b.txt');
+
+        expect(generator.readDestination('b.txt')).toBe('foo');
+        expect(generator.existsDestination('a.txt')).toBe(false);
+      } finally {
+        destinationRootStub.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
`moveDestination` passed the source path to `mem-fs-editor`'s `move()` unresolved, relying on the `fromBasePath` copy option instead. `move()` is a `copy()` followed by a `delete()` of the source, and `delete()` ignores `fromBasePath` — it resolves relative paths against `process.cwd()`.

So whenever the destination root differed from the cwd, the copy landed correctly but the source was never removed (or, worse, a same-named file under the cwd was removed instead), silently degrading the move to a copy.

`fromBasePath` is still passed so the glob root for multi-file moves, and therefore the destination layout, is unchanged.

<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/.github/blob/master/.github/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [ ] Enhancement
- [ ] Other, please explain:

## What changes did you make?

<!-- Give an overview -->

## Is there anything you'd like reviewers to focus on?

<!-- Just in case -->