### PR TITLE
feat!: throw when `templatePath()`/`destinationPath()` resolve outsid…

### DIFF
--- a/src/actions/fs.ts
+++ b/src/actions/fs.ts
@@ -2,34 +2,25 @@
 import assert from 'node:assert';
 import { type MemFsEditor } from 'mem-fs-editor';
 import type { BaseGenerator } from '../generator.js';
+import type { PathOptions } from '../types.js';
+import { splitPathOptions } from '../util/path-options.js';
 
-type ExtractOverload1<T> = T extends {
-  (...args: infer P): infer R; // Captura a 2ª (P = Parâmetros, R = Retorno)
-  (...args: any[]): any; // Ignora a 1ª
-  (...args: any[]): any; // Ignora a 1ª
-  (...args: any[]): any; // Ignora a 1ª
-}
-  ? (...args: P) => R
-  : never;
+type CopyOptions = NonNullable<Parameters<MemFsEditor['copy']>[2]>;
+type CopyAsyncOptions = NonNullable<Parameters<MemFsEditor['copyAsync']>[2]>;
+type WriteOptions = NonNullable<Parameters<MemFsEditor['write']>[2]>;
+type WriteJSONParameters = Parameters<MemFsEditor['writeJSON']>;
+type WriteJSONReplacer = WriteJSONParameters[2];
+type WriteJSONSpace = WriteJSONParameters[3];
+type WriteJSONOptions = WriteOptions & PathOptions & { replacer?: WriteJSONReplacer; space?: WriteJSONSpace };
+type DeleteOptions = NonNullable<Parameters<MemFsEditor['delete']>[1]>;
+type CopyTplOptions = NonNullable<Parameters<MemFsEditor['copyTpl']>[3]>;
+type CopyTplAsyncOptions = NonNullable<Parameters<MemFsEditor['copyTplAsync']>[3]>;
 
-type ExtractOverload2<T> = T extends {
-  (...args: any[]): any; // Ignora a 1ª
-  (...args: infer P): infer R; // Captura a 2ª (P = Parâmetros, R = Retorno)
-  (...args: any[]): any; // Ignora a 1ª
-  (...args: any[]): any; // Ignora a 1ª
-}
-  ? (...args: P) => R
-  : never;
-
-type ReadOverload1 = ExtractOverload1<MemFsEditor['read']>;
-type ReadOverload2 = ExtractOverload2<MemFsEditor['read']>;
-
-type ReadJSONOverload1 = ExtractOverload1<MemFsEditor['readJSON']>;
-type ReadJSONOverload2 = ExtractOverload2<MemFsEditor['readJSON']>;
+type ReadOptions = { raw?: boolean; defaults?: string | Buffer | null };
 
 export type Template<G, C extends 'copyTplAsync' | 'copyTpl', D extends NonNullable<Parameters<MemFsEditor[C]>[2]>> = {
   /**
-   * Template file, absolute or relative to templatePath().
+   * Template file, relative to templatePath(), or absolute inside the source root (outside when the `allowTemplatesOutsideRoot` feature is enabled).
    */
   source: string;
   /**
@@ -40,13 +31,13 @@ export type Template<G, C extends 'copyTplAsync' | 'copyTpl', D extends NonNulla
    */
   when?: (data: D, generator: G) => boolean;
   /**
-   * Destination, absolute or relative to destinationPath().
+   * Destination, relative to destinationPath(), or absolute inside the destination root (outside when the `allowDestinationOutsideRoot` feature is enabled).
    */
   destination?: string;
   /**
-   * Mem-fs-editor copy options
+   * Mem-fs-editor copy options, `allowOutsideRoot` applies to both source and destination.
    */
-  copyOptions?: NonNullable<Parameters<MemFsEditor[C]>[3]>;
+  copyOptions?: NonNullable<Parameters<MemFsEditor[C]>[3]> & PathOptions;
   /**
    * Ejs data
    */
@@ -59,23 +50,17 @@ export type Templates<
   D extends NonNullable<Parameters<MemFsEditor[C]>[2]>,
 > = Array<Template<G, C, D>>;
 
-function applyToFirstStringArg<Type extends [string | string[], ...any] = [string | string[], ...any[]]>(
-  customizer: (arg1: string) => string,
-  args: Type,
-): Type {
-  args[0] = Array.isArray(args[0]) ? args[0].map(arg => customizer(arg)) : customizer(args[0]);
-  return args;
-}
+/**
+ * A replacer is a function, an array or null, so a plain object in its position is the options object.
+ */
+const isWriteJSONOptions = (value: WriteJSONReplacer | WriteJSONOptions): value is WriteJSONOptions =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
 
-function applyToFirstAndSecondStringArg<Type extends [string | string[], string, ...any]>(
-  customizer1: (arg1: string) => string,
-  customizer2: (arg1: string) => string,
-  args: Type,
-): Type {
-  args = applyToFirstStringArg(customizer1, args);
-  args[1] = customizer2(args[1]);
-  return args;
-}
+const writeJSONOptionsToPositional = ({
+  replacer,
+  space,
+  ...options
+}: WriteJSONOptions): [WriteJSONReplacer?, WriteJSONSpace?, (WriteOptions & PathOptions)?] => [replacer, space, options];
 
 type EditorMetadataOptions = { metadata?: Record<string, unknown> };
 
@@ -104,15 +89,26 @@ export class FsMixin {
    * mem-fs-editor method's shortcut, for more information see [mem-fs-editor]{@link https://github.com/SBoudrias/mem-fs-editor}.
    * Shortcut for this.fs!.read(this.templatePath(filepath))
    */
-  readTemplate(this: BaseGenerator, ...args: Parameters<ReadOverload1>): ReturnType<ReadOverload1>;
-  readTemplate(this: BaseGenerator, ...args: Parameters<ReadOverload2>): ReturnType<ReadOverload2>;
+  readTemplate(this: BaseGenerator, filepath: string, options?: PathOptions): string;
+  readTemplate<const DefaultType extends string | null>(
+    this: BaseGenerator,
+    filepath: string,
+    options: { raw?: false; defaults: DefaultType } & PathOptions,
+  ): string | DefaultType;
+  readTemplate(this: BaseGenerator, filepath: string, options: { raw: true; defaults?: never } & PathOptions): Buffer;
+  readTemplate<const DefaultType extends Buffer | null>(
+    this: BaseGenerator,
+    filepath: string,
+    options: { raw: true; defaults: DefaultType } & PathOptions,
+  ): Buffer | DefaultType;
   readTemplate(
     this: BaseGenerator,
-    ...args: Parameters<ReadOverload1> | Parameters<ReadOverload2>
-  ): ReturnType<ReadOverload1> | ReturnType<ReadOverload2> {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    return this.fs.read(...applyToFirstStringArg(this.templatePath.bind(this), args));
+    ...args: [filepath: string, options?: ReadOptions & PathOptions]
+  ): string | Buffer | null {
+    const [filepath, options, ...remaining] = args;
+    const [pathOptions, readOptions] = splitPathOptions(options);
+
+    return (this.fs.read as any)(this.templatePath(filepath, pathOptions), readOptions, ...remaining);
   }
 
   /**
@@ -120,13 +116,17 @@ export class FsMixin {
    * mem-fs-editor method's shortcut, for more information see [mem-fs-editor]{@link https://github.com/SBoudrias/mem-fs-editor}.
    * Shortcut for this.fs!.copy(this.templatePath(from), this.destinationPath(to))
    */
-  copyTemplate(this: BaseGenerator, ...args: Parameters<MemFsEditor['copy']>): ReturnType<MemFsEditor['copy']> {
-    const [from, to, options = {}, ...remaining] = args;
+  copyTemplate(
+    this: BaseGenerator,
+    ...args: [from: string | string[], to: string, options?: CopyOptions & PathOptions]
+  ): ReturnType<MemFsEditor['copy']> {
+    const [from, to, options, ...remaining] = args;
+    const [pathOptions, copyOptions] = splitPathOptions(options);
 
     return this.fs.copy(
       from,
-      this.destinationPath(to),
-      withEditorMetadata(this, { fromBasePath: this.templatePath(), ...options }),
+      this.destinationPath(to, pathOptions),
+      withEditorMetadata(this, { fromBasePath: this.templatePath(), ...copyOptions }),
       ...remaining,
     );
   }
@@ -138,15 +138,18 @@ export class FsMixin {
    */
   async copyTemplateAsync(
     this: BaseGenerator,
-    ...args: Parameters<MemFsEditor['copyAsync']>
+    ...args: [from: string | string[], to: string, options?: CopyAsyncOptions & PathOptions]
   ): ReturnType<MemFsEditor['copyAsync']> {
-    const [from, to, options, ...remaining] = applyToFirstAndSecondStringArg(
-      this.templatePath.bind(this),
-      this.destinationPath.bind(this),
-      args,
-    );
+    const [from, to, options, ...remaining] = args;
+    const [pathOptions, copyOptions] = splitPathOptions(options);
+    const templatePath = (filepath: string) => this.templatePath(filepath, pathOptions);
 
-    return this.fs.copyAsync(from, to, withEditorMetadata(this, options), ...remaining);
+    return this.fs.copyAsync(
+      Array.isArray(from) ? from.map(filepath => templatePath(filepath)) : templatePath(from),
+      this.destinationPath(to, pathOptions),
+      withEditorMetadata(this, copyOptions),
+      ...remaining,
+    );
   }
 
   /**
@@ -154,15 +157,26 @@ export class FsMixin {
    * mem-fs-editor method's shortcut, for more information see [mem-fs-editor]{@link https://github.com/SBoudrias/mem-fs-editor}.
    * Shortcut for this.fs!.read(this.destinationPath(filepath)).
    */
-  readDestination(this: BaseGenerator, ...args: Parameters<ReadOverload1>): ReturnType<ReadOverload1>;
-  readDestination(this: BaseGenerator, ...args: Parameters<ReadOverload2>): ReturnType<ReadOverload2>;
+  readDestination(this: BaseGenerator, filepath: string, options?: PathOptions): string;
+  readDestination<const DefaultType extends string | null>(
+    this: BaseGenerator,
+    filepath: string,
+    options: { raw?: false; defaults: DefaultType } & PathOptions,
+  ): string | DefaultType;
+  readDestination(this: BaseGenerator, filepath: string, options: { raw: true; defaults?: never } & PathOptions): Buffer;
+  readDestination<const DefaultType extends Buffer | null>(
+    this: BaseGenerator,
+    filepath: string,
+    options: { raw: true; defaults: DefaultType } & PathOptions,
+  ): Buffer | DefaultType;
   readDestination(
     this: BaseGenerator,
-    ...args: Parameters<ReadOverload1> | Parameters<ReadOverload2>
-  ): ReturnType<ReadOverload1> | ReturnType<ReadOverload2> {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    return this.fs.read(...applyToFirstStringArg(this.destinationPath.bind(this), args));
+    ...args: [filepath: string, options?: ReadOptions & PathOptions]
+  ): string | Buffer | null {
+    const [filepath, options, ...remaining] = args;
+    const [pathOptions, readOptions] = splitPathOptions(options);
+
+    return (this.fs.read as any)(this.destinationPath(filepath, pathOptions), readOptions, ...remaining);
   }
 
   /**
@@ -170,13 +184,15 @@ export class FsMixin {
    * mem-fs-editor method's shortcut, for more information see [mem-fs-editor]{@link https://github.com/SBoudrias/mem-fs-editor}.
    * Shortcut for this.fs!.readJSON(this.destinationPath(filepath)).
    */
-  readDestinationJSON(this: BaseGenerator, ...args: Parameters<ReadJSONOverload1>): ReturnType<ReadJSONOverload1>;
-  readDestinationJSON(this: BaseGenerator, ...args: Parameters<ReadJSONOverload2>): ReturnType<ReadJSONOverload2>;
+  readDestinationJSON(this: BaseGenerator, filepath: string, defaults?: undefined, options?: PathOptions): object | undefined;
+  readDestinationJSON<T>(this: BaseGenerator, filepath: string, defaults: T, options?: PathOptions): object | T;
   readDestinationJSON(
     this: BaseGenerator,
-    ...args: Parameters<ReadJSONOverload1> | Parameters<ReadJSONOverload2>
-  ): ReturnType<ReadJSONOverload1> | ReturnType<ReadJSONOverload2> {
-    return this.fs.readJSON(...applyToFirstStringArg(this.destinationPath.bind(this), args));
+    ...args: [filepath: string, defaults?: unknown, options?: PathOptions]
+  ): object | unknown {
+    const [filepath, defaults, options, ...remaining] = args;
+
+    return (this.fs.readJSON as any)(this.destinationPath(filepath, options ?? {}), defaults, options, ...remaining);
   }
 
   /**
@@ -184,10 +200,19 @@ export class FsMixin {
    * mem-fs-editor method's shortcut, for more information see [mem-fs-editor]{@link https://github.com/SBoudrias/mem-fs-editor}.
    * Shortcut for this.fs!.write(this.destinationPath(filepath)).
    */
-  writeDestination(this: BaseGenerator, ...args: Parameters<MemFsEditor['write']>): ReturnType<MemFsEditor['write']> {
-    const [filepath, contents, options, ...remaining] = applyToFirstStringArg(this.destinationPath.bind(this), args);
+  writeDestination(
+    this: BaseGenerator,
+    ...args: [filepath: string, contents: string | Buffer, options?: WriteOptions & PathOptions]
+  ): ReturnType<MemFsEditor['write']> {
+    const [filepath, contents, options, ...remaining] = args;
+    const [pathOptions, writeOptions] = splitPathOptions(options);
 
-    return this.fs.write(filepath, contents, withEditorMetadata(this, options), ...remaining);
+    return this.fs.write(
+      this.destinationPath(filepath, pathOptions),
+      contents,
+      withEditorMetadata(this, writeOptions),
+      ...remaining,
+    );
   }
 
   /**
@@ -197,14 +222,43 @@ export class FsMixin {
    */
   writeDestinationJSON(
     this: BaseGenerator,
-    ...args: Parameters<MemFsEditor['writeJSON']>
+    filepath: string,
+    contents: unknown,
+    options?: WriteJSONOptions,
+  ): ReturnType<MemFsEditor['writeJSON']>;
+  writeDestinationJSON(
+    this: BaseGenerator,
+    filepath: string,
+    contents: unknown,
+    replacer?: WriteJSONReplacer,
+    space?: WriteJSONSpace,
+    options?: WriteOptions & PathOptions,
+  ): ReturnType<MemFsEditor['writeJSON']>;
+  writeDestinationJSON(
+    this: BaseGenerator,
+    ...args: [
+      filepath: string,
+      contents: unknown,
+      replacerOrOptions?: WriteJSONReplacer | WriteJSONOptions,
+      space?: WriteJSONSpace,
+      options?: WriteOptions & PathOptions,
+    ]
   ): ReturnType<MemFsEditor['writeJSON']> {
-    const [filepath, contents, replacer, space, options, ...remaining] = applyToFirstStringArg(
-      this.destinationPath.bind(this),
-      args,
-    );
+    const [filepath, contents, ...rest] = args;
+    // Normalize the `writeDestinationJSON(filepath, contents, options)` form to the positional one.
+    const [replacer, space, options, ...remaining] = isWriteJSONOptions(rest[0])
+      ? writeJSONOptionsToPositional(rest[0])
+      : (rest as [WriteJSONReplacer?, WriteJSONSpace?, (WriteOptions & PathOptions)?]);
+    const [pathOptions, writeOptions] = splitPathOptions(options);
 
-    return this.fs.writeJSON(filepath, contents, replacer, space, withEditorMetadata(this, options), ...remaining);
+    return this.fs.writeJSON(
+      this.destinationPath(filepath, pathOptions),
+      contents,
+      replacer,
+      space,
+      withEditorMetadata(this, writeOptions),
+      ...remaining,
+    );
   }
 
   /**
@@ -214,9 +268,17 @@ export class FsMixin {
    */
   deleteDestination(
     this: BaseGenerator,
-    ...args: Parameters<MemFsEditor['delete']>
+    ...args: [paths: string | string[], options?: DeleteOptions & PathOptions]
   ): ReturnType<MemFsEditor['delete']> {
-    return this.fs.delete(...applyToFirstStringArg(this.destinationPath.bind(this), args));
+    const [paths, options, ...remaining] = args;
+    const [pathOptions, deleteOptions] = splitPathOptions(options);
+    const destinationPath = (filepath: string) => this.destinationPath(filepath, pathOptions);
+
+    return this.fs.delete(
+      Array.isArray(paths) ? paths.map(filepath => destinationPath(filepath)) : destinationPath(paths),
+      deleteOptions,
+      ...remaining,
+    );
   }
 
   /**
@@ -224,13 +286,17 @@ export class FsMixin {
    * mem-fs-editor method's shortcut, for more information see [mem-fs-editor]{@link https://github.com/SBoudrias/mem-fs-editor}.
    * Shortcut for this.fs!.copy(this.destinationPath(from), this.destinationPath(to)).
    */
-  copyDestination(this: BaseGenerator, ...args: Parameters<MemFsEditor['copy']>): ReturnType<MemFsEditor['copy']> {
-    const [from, to, options = {}, ...remaining] = args;
+  copyDestination(
+    this: BaseGenerator,
+    ...args: [from: string | string[], to: string, options?: CopyOptions & PathOptions]
+  ): ReturnType<MemFsEditor['copy']> {
+    const [from, to, options, ...remaining] = args;
+    const [pathOptions, copyOptions] = splitPathOptions(options);
 
     return this.fs.copy(
       from,
-      this.destinationPath(to),
-      withEditorMetadata(this, { fromBasePath: this.destinationPath(), ...options }),
+      this.destinationPath(to, pathOptions),
+      withEditorMetadata(this, { fromBasePath: this.destinationPath(), ...copyOptions }),
       ...remaining,
     );
   }
@@ -240,13 +306,17 @@ export class FsMixin {
    * mem-fs-editor method's shortcut, for more information see [mem-fs-editor]{@link https://github.com/SBoudrias/mem-fs-editor}.
    * Shortcut for this.fs!.move(this.destinationPath(from), this.destinationPath(to)).
    */
-  moveDestination(this: BaseGenerator, ...args: Parameters<MemFsEditor['move']>): ReturnType<MemFsEditor['move']> {
+  moveDestination(
+    this: BaseGenerator,
+    ...args: [from: string, to: string, options?: CopyOptions & PathOptions]
+  ): ReturnType<MemFsEditor['move']> {
     const [from, to, options, ...remaining] = args;
+    const [pathOptions, moveOptions] = splitPathOptions(options);
 
     return this.fs.move(
-      this.destinationPath(from),
-      this.destinationPath(to),
-      { fromBasePath: this.destinationPath(), ...options },
+      this.destinationPath(from, pathOptions),
+      this.destinationPath(to, pathOptions),
+      { fromBasePath: this.destinationPath(), ...moveOptions },
       ...remaining,
     );
   }
@@ -258,34 +328,36 @@ export class FsMixin {
    */
   existsDestination(
     this: BaseGenerator,
-    ...args: Parameters<MemFsEditor['exists']>
+    ...args: [filepath: string, options?: PathOptions]
   ): ReturnType<MemFsEditor['exists']> {
-    return this.fs.exists(...applyToFirstStringArg(this.destinationPath.bind(this), args));
+    const [filepath, options, ...remaining] = args;
+
+    return (this.fs.exists as any)(this.destinationPath(filepath, options ?? {}), options, ...remaining);
   }
 
   /**
    * Copy a template from templates folder to the destination.
    *
-   * @param source - template file, absolute or relative to templatePath().
-   * @param destination - destination, absolute or relative to destinationPath().
+   * @param source - template file, relative to templatePath(), or absolute inside the source root (outside when the `allowTemplatesOutsideRoot` feature is enabled).
+   * @param destination - destination, relative to destinationPath(), or absolute inside the destination root (outside when the `allowDestinationOutsideRoot` feature is enabled).
    * @param templateData - ejs data
    * @param templateOptions - ejs options
-   * @param copyOptions - mem-fs-editor copy options
+   * @param copyOptions - mem-fs-editor copy options, `allowOutsideRoot` applies to both source and destination
    */
   renderTemplate<const D extends NonNullable<Parameters<MemFsEditor['copyTpl']>[2]>>(
     this: BaseGenerator,
     source?: string | string[],
     destination?: string | string[],
     templateData?: string | D,
-    copyOptions?: NonNullable<Parameters<MemFsEditor['copyTpl']>[3]>,
+    copyOptions?: CopyTplOptions & PathOptions,
   ): void;
   renderTemplate<const D extends NonNullable<Parameters<MemFsEditor['copyTpl']>[2]>>(
     this: BaseGenerator,
     source: string | string[] = '',
     destination: string | string[] = source,
     templateData?: string | D,
-    copyOptions?: NonNullable<Parameters<MemFsEditor['copyTpl']>[3]>,
-    compatOptions?: NonNullable<Parameters<MemFsEditor['copyTpl']>[3]>,
+    copyOptions?: CopyTplOptions & PathOptions,
+    compatOptions?: CopyTplOptions,
   ): void {
     if (compatOptions || 'context' in (copyOptions ?? {})) {
       copyOptions = { ...compatOptions, transformOptions: copyOptions as any };
@@ -295,10 +367,11 @@ export class FsMixin {
       templateData = this._templateData(templateData) as D;
     }
 
+    const [pathOptions, copyTplOptions] = splitPathOptions(copyOptions);
     source = Array.isArray(source) ? source : [source];
-    const templatePath = this.templatePath(...source);
+    const templatePath = this.templatePath(...source, pathOptions);
     destination = Array.isArray(destination) ? destination : [destination];
-    const destinationPath = this.destinationPath(...destination);
+    const destinationPath = this.destinationPath(...destination, pathOptions);
 
     this.fs.copyTpl(
       templatePath,
@@ -306,10 +379,10 @@ export class FsMixin {
       templateData,
       withEditorMetadata(this, {
         fromBasePath: this.templatePath(),
-        ...copyOptions,
+        ...copyTplOptions,
         transformOptions: {
           context: this,
-          ...copyOptions?.transformOptions,
+          ...copyTplOptions?.transformOptions,
         },
       }),
     );
@@ -318,26 +391,26 @@ export class FsMixin {
   /**
    * Copy a template from templates folder to the destination.
    *
-   * @param source - template file, absolute or relative to templatePath().
-   * @param destination - destination, absolute or relative to destinationPath().
+   * @param source - template file, relative to templatePath(), or absolute inside the source root (outside when the `allowTemplatesOutsideRoot` feature is enabled).
+   * @param destination - destination, relative to destinationPath(), or absolute inside the destination root (outside when the `allowDestinationOutsideRoot` feature is enabled).
    * @param templateData - ejs data
    * @param templateOptions - ejs options
-   * @param copyOptions - mem-fs-editor copy options
+   * @param copyOptions - mem-fs-editor copy options, `allowOutsideRoot` applies to both source and destination
    */
   async renderTemplateAsync<const D extends NonNullable<Parameters<MemFsEditor['copyTplAsync']>[2]>>(
     this: BaseGenerator,
     source?: string | string[],
     destination?: string | string[],
     templateData?: string | D,
-    copyOptions?: NonNullable<Parameters<MemFsEditor['copyTplAsync']>[3]>,
+    copyOptions?: CopyTplAsyncOptions & PathOptions,
   ): Promise<void>;
   async renderTemplateAsync<const D extends NonNullable<Parameters<MemFsEditor['copyTplAsync']>[2]>>(
     this: BaseGenerator,
     source: string | string[] = '',
     destination: string | string[] = source,
     templateData?: string | D,
-    copyOptions?: NonNullable<Parameters<MemFsEditor['copyTplAsync']>[3]>,
-    compatOptions?: NonNullable<Parameters<MemFsEditor['copyTplAsync']>[3]>,
+    copyOptions?: CopyTplAsyncOptions & PathOptions,
+    compatOptions?: CopyTplAsyncOptions,
   ): Promise<void> {
     if (compatOptions || 'context' in (copyOptions ?? {})) {
       copyOptions = { ...compatOptions, transformOptions: copyOptions as any };
@@ -347,10 +420,11 @@ export class FsMixin {
       templateData = this._templateData(templateData) as D;
     }
 
+    const [pathOptions, copyTplOptions] = splitPathOptions(copyOptions);
     source = Array.isArray(source) ? source : [source];
-    const templatePath = this.templatePath(...source);
+    const templatePath = this.templatePath(...source, pathOptions);
     destination = Array.isArray(destination) ? destination : [destination];
-    const destinationPath = this.destinationPath(...destination);
+    const destinationPath = this.destinationPath(...destination, pathOptions);
 
     return this.fs.copyTplAsync(
       templatePath,
@@ -358,10 +432,10 @@ export class FsMixin {
       templateData,
       withEditorMetadata(this, {
         fromBasePath: this.templatePath(),
-        ...copyOptions,
+        ...copyTplOptions,
         transformOptions: {
           context: this,
-          ...copyOptions?.transformOptions,
+          ...copyTplOptions?.transformOptions,
         },
       }),
     );
@@ -394,7 +468,7 @@ export class FsMixin {
   /**
    * Copy templates from templates folder to the destination.
    *
-   * @param templates - template file, absolute or relative to templatePath().
+   * @param templates - template file, relative to templatePath(), or absolute inside the source root (outside when the `allowTemplatesOutsideRoot` feature is enabled).
    * @param templateData - ejs data
    */
   async renderTemplatesAsync<const D extends NonNullable<Parameters<MemFsEditor['copyTplAsync']>[2]>>(

--- a/src/actions/fs.ts
+++ b/src/actions/fs.ts
@@ -60,7 +60,11 @@ const writeJSONOptionsToPositional = ({
   replacer,
   space,
   ...options
-}: WriteJSONOptions): [WriteJSONReplacer?, WriteJSONSpace?, (WriteOptions & PathOptions)?] => [replacer, space, options];
+}: WriteJSONOptions): [WriteJSONReplacer?, WriteJSONSpace?, (WriteOptions & PathOptions)?] => [
+  replacer,
+  space,
+  options,
+];
 
 type EditorMetadataOptions = { metadata?: Record<string, unknown> };
 
@@ -163,7 +167,11 @@ export class FsMixin {
     filepath: string,
     options: { raw?: false; defaults: DefaultType } & PathOptions,
   ): string | DefaultType;
-  readDestination(this: BaseGenerator, filepath: string, options: { raw: true; defaults?: never } & PathOptions): Buffer;
+  readDestination(
+    this: BaseGenerator,
+    filepath: string,
+    options: { raw: true; defaults?: never } & PathOptions,
+  ): Buffer;
   readDestination<const DefaultType extends Buffer | null>(
     this: BaseGenerator,
     filepath: string,
@@ -184,7 +192,12 @@ export class FsMixin {
    * mem-fs-editor method's shortcut, for more information see [mem-fs-editor]{@link https://github.com/SBoudrias/mem-fs-editor}.
    * Shortcut for this.fs!.readJSON(this.destinationPath(filepath)).
    */
-  readDestinationJSON(this: BaseGenerator, filepath: string, defaults?: undefined, options?: PathOptions): object | undefined;
+  readDestinationJSON(
+    this: BaseGenerator,
+    filepath: string,
+    defaults?: undefined,
+    options?: PathOptions,
+  ): object | undefined;
   readDestinationJSON<T>(this: BaseGenerator, filepath: string, defaults: T, options?: PathOptions): object | T;
   readDestinationJSON(
     this: BaseGenerator,

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -18,12 +18,13 @@ import type {
   Logger,
   QueuedAdapter,
 } from '@yeoman/types';
-import type { ArgumentSpec, BaseFeatures, BaseOptions, CliOptionSpec } from './types.js';
+import type { ArgumentSpec, BaseFeatures, BaseOptions, CliOptionSpec, PathOptions } from './types.js';
 import type { PromptAnswers, PromptQuestion, PromptQuestions, QuestionRegistrationOptions } from './questions.js';
 import Storage, { type StorageOptions } from './util/storage.js';
 import { prefillQuestions, storeAnswers } from './util/prompt-suggestion.js';
 import { DESTINATION_ROOT_CHANGE_EVENT, requiredEnvironmentVersion } from './constants.js';
 import { FsMixin } from './actions/fs.js';
+import { splitPathOptions } from './util/path-options.js';
 import { HelpMixin } from './actions/help.js';
 import { PackageJsonMixin } from './actions/package-json.js';
 import { SpawnCommandMixin } from './actions/spawn-command.js';
@@ -37,6 +38,36 @@ const _filename = fileURLToPath(import.meta.url);
 const _dirname = dirname(_filename);
 
 const EMPTY = '@@_YEOMAN_EMPTY_MARKER_@@';
+
+type PathArguments = string[] | [...dest: string[], options: PathOptions];
+
+/**
+ * Split the trailing `PathOptions` object, when present, from the path parts.
+ */
+const splitPathArguments = (args: PathArguments): [dest: string[], options: PathOptions | undefined] => {
+  const last = args.at(-1);
+  if (last !== undefined && typeof last !== 'string') {
+    return [args.slice(0, -1) as string[], last];
+  }
+
+  return [args as string[], undefined];
+};
+
+/**
+ * Join path parts, resolving relative paths against the root and keeping absolute paths as is.
+ */
+const joinToRoot = (root: string, dest: string[]): string => {
+  const filepath = path.join(...dest);
+  return path.isAbsolute(filepath) ? filepath : path.join(root, filepath);
+};
+
+/**
+ * Whether `filepath` is the root itself or a descendant of it.
+ */
+const isInsideRoot = (root: string, filepath: string): boolean => {
+  const relative = path.relative(path.resolve(root), path.resolve(filepath));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+};
 
 const ENV_VER_WITH_VER_API = '2.9.0';
 
@@ -776,20 +807,20 @@ export class BaseGenerator<
 
   /**
    * Return a storage instance.
-   * @param storePath  The path of the json file
-   * @param options storage options or the storage name
+   * @param storePath  The path of the json file, relative to the destination root
+   * @param options storage options or the storage name, `allowOutsideRoot` allows a store path outside the destination root
    */
   createStorage<StoredType extends Record<any, any> = Record<any, any>>(
     storePath: string,
-    options?: string | StorageOptions,
+    options?: string | (StorageOptions & PathOptions),
   ): Storage<StoredType>;
-  createStorage(storePath: string, options?: string | StorageOptions): Storage<Record<string, any>> {
+  createStorage(storePath: string, options?: string | (StorageOptions & PathOptions)): Storage<Record<string, any>> {
     if (typeof options === 'string') {
       options = { name: options };
     }
 
-    storePath = this.destinationPath(storePath);
-    return new Storage(this.fs, storePath, options);
+    const [pathOptions, storageOptions] = splitPathOptions(options);
+    return new Storage(this.fs, this.destinationPath(storePath, pathOptions), storageOptions);
   }
 
   /**
@@ -823,7 +854,12 @@ export class BaseGenerator<
     const globalStorageDir = this.options.localConfigOnly ? this.destinationRoot() : os.homedir();
     const storePath = path.join(globalStorageDir, '.yo-rc-global.json');
     const storeName = `${this.rootGeneratorName()}:${this.rootGeneratorVersion()}`;
-    return this.createStorage(storePath, { transform: this.#features.configTransform, name: storeName });
+    // The global storage lives outside the destination root by design.
+    return this.createStorage(storePath, {
+      transform: this.#features.configTransform,
+      name: storeName,
+      allowOutsideRoot: true,
+    });
   }
 
   /**
@@ -869,14 +905,20 @@ export class BaseGenerator<
 
   /**
    * Join a path to the source root.
-   * @param dest - path parts
+   * Throws if the resulting path is not inside the source root, unless the `allowTemplatesOutsideRoot` feature or the `allowOutsideRoot` option is enabled.
+   * @param dest - path parts, optionally followed by a `PathOptions` object
    * @return joined path
    */
-  templatePath(...dest: string[]): string {
-    let filepath = path.join(...dest);
-
-    if (!path.isAbsolute(filepath)) {
-      filepath = path.join(this.sourceRoot(), filepath);
+  templatePath(...dest: string[]): string;
+  templatePath(...args: [...dest: string[], options: PathOptions]): string;
+  templatePath(...args: PathArguments): string {
+    const [dest, options] = splitPathArguments(args);
+    const root = this.sourceRoot();
+    const filepath = joinToRoot(root, dest);
+    if (!(options?.allowOutsideRoot ?? this.#features.allowTemplatesOutsideRoot) && !isInsideRoot(root, filepath)) {
+      throw new Error(
+        `templatePath() resolved '${filepath}' outside the source root '${root}'. Pass a path inside the root, enable the 'allowTemplatesOutsideRoot' feature, or pass the '{ allowOutsideRoot: true }' option.`,
+      );
     }
 
     return filepath;
@@ -884,14 +926,20 @@ export class BaseGenerator<
 
   /**
    * Join a path to the destination root.
-   * @param dest - path parts
+   * Throws if the resulting path is not inside the destination root, unless the `allowDestinationOutsideRoot` feature or the `allowOutsideRoot` option is enabled.
+   * @param dest - path parts, optionally followed by a `PathOptions` object
    * @return joined path
    */
-  destinationPath(...dest: string[]): string {
-    let filepath = path.join(...dest);
-
-    if (!path.isAbsolute(filepath)) {
-      filepath = path.join(this.destinationRoot(), filepath);
+  destinationPath(...dest: string[]): string;
+  destinationPath(...args: [...dest: string[], options: PathOptions]): string;
+  destinationPath(...args: PathArguments): string {
+    const [dest, options] = splitPathArguments(args);
+    const root = this.destinationRoot();
+    const filepath = joinToRoot(root, dest);
+    if (!(options?.allowOutsideRoot ?? this.#features.allowDestinationOutsideRoot) && !isInsideRoot(root, filepath)) {
+      throw new Error(
+        `destinationPath() resolved '${filepath}' outside the destination root '${root}'. Pass a path inside the root, enable the 'allowDestinationOutsideRoot' feature, or pass the '{ allowOutsideRoot: true }' option.`,
+      );
     }
 
     return filepath;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -111,9 +111,30 @@ export type BaseFeatures = Merge<
 
     /** Transform the configuration before reading. */
     configTransform?: StorageTransform<Record<string, any>>;
+
+    /**
+     * Allow `templatePath()` to resolve paths outside the source root.
+     * By default a resulting path that is not inside the source root throws.
+     * Can be overridden per call using the `allowOutsideRoot` option.
+     */
+    allowTemplatesOutsideRoot?: boolean;
+
+    /**
+     * Allow `destinationPath()` to resolve paths outside the destination root.
+     * By default a resulting path that is not inside the destination root throws.
+     * Can be overridden per call using the `allowOutsideRoot` option.
+     */
+    allowDestinationOutsideRoot?: boolean;
   },
   FeaturesApi
 >;
+
+export type PathOptions = {
+  /**
+   * Allow the resulting path to be outside the root, overriding the `allowTemplatesOutsideRoot`/`allowDestinationOutsideRoot` feature.
+   */
+  allowOutsideRoot?: boolean;
+};
 
 export type BaseOptions = OptionsApi & {
   destinationRoot?: string;

--- a/src/util/path-options.ts
+++ b/src/util/path-options.ts
@@ -1,0 +1,16 @@
+import type { PathOptions } from '../types.js';
+
+/**
+ * Split `PathOptions` from an options object so the remaining options can be forwarded untouched.
+ * Objects without a path option (including `fs.Stats` instances) are returned as is, not copied.
+ */
+export function splitPathOptions<T extends object>(
+  options: (T & PathOptions) | undefined,
+): [pathOptions: PathOptions, options: T | undefined] {
+  if (!options || typeof options !== 'object' || !('allowOutsideRoot' in options)) {
+    return [{}, options];
+  }
+
+  const { allowOutsideRoot, ...remaining } = options;
+  return [{ allowOutsideRoot }, remaining as T];
+}

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -1108,16 +1108,106 @@ describe('Base', () => {
   });
 
   describe('#templatePath()', () => {
+    const outsidePath = path.resolve('/outside/bar.js');
+
     it('joins path to the source root', () => {
       expect(dummy.templatePath('bar.js')).toBe(path.join(dummy.sourceRoot(), 'bar.js'));
       expect(dummy.templatePath('dir/', 'bar.js')).toBe(path.join(dummy.sourceRoot(), '/dir/bar.js'));
+      expect(dummy.templatePath()).toBe(dummy.sourceRoot());
+    });
+
+    it('ignores a trailing options object when joining', () => {
+      expect(dummy.templatePath('dir/', 'bar.js', {})).toBe(path.join(dummy.sourceRoot(), '/dir/bar.js'));
+    });
+
+    it('accepts absolute path inside the source root', () => {
+      const inside = path.join(dummy.sourceRoot(), 'dir', 'bar.js');
+      expect(dummy.templatePath(inside)).toBe(inside);
+      expect(dummy.templatePath(dummy.sourceRoot())).toBe(dummy.sourceRoot());
+    });
+
+    it('throws on path outside the source root by default', () => {
+      expect(() => dummy.templatePath(outsidePath)).toThrow(/templatePath\(\) resolved .* outside the source root/);
+      expect(() => dummy.templatePath('..', 'bar.js')).toThrow(/allowTemplatesOutsideRoot/);
+      expect(() => dummy.templatePath('dir/../../bar.js')).toThrow(/outside the source root/);
+      expect(() => dummy.templatePath(`${dummy.sourceRoot()}-sibling/bar.js`)).toThrow(/outside the source root/);
+    });
+
+    it('allows path outside the source root with allowOutsideRoot option', () => {
+      expect(dummy.templatePath(outsidePath, { allowOutsideRoot: true })).toBe(outsidePath);
+      expect(dummy.templatePath('..', 'bar.js', { allowOutsideRoot: true })).toBe(
+        path.join(dummy.sourceRoot(), '..', 'bar.js'),
+      );
+    });
+
+    it('allows path outside the source root with allowTemplatesOutsideRoot feature', () => {
+      const generator = new Dummy([], { env, resolved: 'foo/bar' }, { allowTemplatesOutsideRoot: true });
+      expect(generator.templatePath(outsidePath)).toBe(outsidePath);
+    });
+
+    it('ignores allowDestinationOutsideRoot feature', () => {
+      const generator = new Dummy([], { env, resolved: 'foo/bar' }, { allowDestinationOutsideRoot: true });
+      expect(() => generator.templatePath(outsidePath)).toThrow(/outside the source root/);
+    });
+
+    it('option takes precedence over feature', () => {
+      const generator = new Dummy([], { env, resolved: 'foo/bar' }, { allowTemplatesOutsideRoot: true });
+      expect(() => generator.templatePath(outsidePath, { allowOutsideRoot: false })).toThrow(/outside the source root/);
     });
   });
 
   describe('#destinationPath()', () => {
-    it('joins path to the source root', () => {
+    const outsidePath = path.resolve('/outside/bar.js');
+
+    it('joins path to the destination root', () => {
       expect(dummy.destinationPath('bar.js')).toBe(path.join(dummy.destinationRoot(), 'bar.js'));
       expect(dummy.destinationPath('dir/', 'bar.js')).toBe(path.join(dummy.destinationRoot(), '/dir/bar.js'));
+      expect(dummy.destinationPath()).toBe(dummy.destinationRoot());
+    });
+
+    it('ignores a trailing options object when joining', () => {
+      expect(dummy.destinationPath('dir/', 'bar.js', {})).toBe(path.join(dummy.destinationRoot(), '/dir/bar.js'));
+    });
+
+    it('accepts absolute path inside the destination root', () => {
+      const inside = path.join(dummy.destinationRoot(), 'dir', 'bar.js');
+      expect(dummy.destinationPath(inside)).toBe(inside);
+      expect(dummy.destinationPath(dummy.destinationRoot())).toBe(dummy.destinationRoot());
+    });
+
+    it('throws on path outside the destination root by default', () => {
+      expect(() => dummy.destinationPath(outsidePath)).toThrow(
+        /destinationPath\(\) resolved .* outside the destination root/,
+      );
+      expect(() => dummy.destinationPath('..', 'bar.js')).toThrow(/allowDestinationOutsideRoot/);
+      expect(() => dummy.destinationPath('dir/../../bar.js')).toThrow(/outside the destination root/);
+      expect(() => dummy.destinationPath(`${dummy.destinationRoot()}-sibling/bar.js`)).toThrow(
+        /outside the destination root/,
+      );
+    });
+
+    it('allows path outside the destination root with allowOutsideRoot option', () => {
+      expect(dummy.destinationPath(outsidePath, { allowOutsideRoot: true })).toBe(outsidePath);
+      expect(dummy.destinationPath('..', 'bar.js', { allowOutsideRoot: true })).toBe(
+        path.join(dummy.destinationRoot(), '..', 'bar.js'),
+      );
+    });
+
+    it('allows path outside the destination root with allowDestinationOutsideRoot feature', () => {
+      const generator = new Dummy([], { env, resolved: 'foo/bar' }, { allowDestinationOutsideRoot: true });
+      expect(generator.destinationPath(outsidePath)).toBe(outsidePath);
+    });
+
+    it('ignores allowTemplatesOutsideRoot feature', () => {
+      const generator = new Dummy([], { env, resolved: 'foo/bar' }, { allowTemplatesOutsideRoot: true });
+      expect(() => generator.destinationPath(outsidePath)).toThrow(/outside the destination root/);
+    });
+
+    it('option takes precedence over feature', () => {
+      const generator = new Dummy([], { env, resolved: 'foo/bar' }, { allowDestinationOutsideRoot: true });
+      expect(() => generator.destinationPath(outsidePath, { allowOutsideRoot: false })).toThrow(
+        /outside the destination root/,
+      );
     });
   });
 

--- a/test/fs.test.ts
+++ b/test/fs.test.ts
@@ -344,7 +344,11 @@ describe('generators.Base (actions/fs)', () => {
 
     it('writeDestinationJSON accepts replacer and space inside options', () => {
       const replacer = ['a'];
-      base.writeDestinationJSON('file', { a: 1 }, { replacer, space: 4, allowOutsideRoot: true, metadata: { foo: 'bar' } });
+      base.writeDestinationJSON(
+        'file',
+        { a: 1 },
+        { replacer, space: 4, allowOutsideRoot: true, metadata: { foo: 'bar' } },
+      );
       const [pathCall] = (base.destinationPath as ReturnType<typeof vi.fn>).mock.calls;
       expect(pathCall).toEqual(['file', { allowOutsideRoot: true }]);
       const [call] = (base.fs.writeJSON as ReturnType<typeof vi.fn>).mock.calls;

--- a/test/fs.test.ts
+++ b/test/fs.test.ts
@@ -149,7 +149,8 @@ describe('generators.Base (actions/fs)', () => {
   for (const operation of testResults) {
     const passedArg1 = randomString();
     const passedArg2 = randomString();
-    const passedArg3 = {};
+    // A plain object in writeDestinationJSON's replacer position selects its options form, so pass an array replacer.
+    const passedArg3 = operation.name === 'writeDestinationJSON' ? ['key'] : {};
     const passedArg4 = { foo: 'bar' };
 
     describe(`#${operation.name as string}`, () => {
@@ -277,6 +278,101 @@ describe('generators.Base (actions/fs)', () => {
         expect(call[3].metadata).toEqual({ foo: 'bar', other: true });
         expect(call[3].transformOptions.context).toBe(base);
       });
+    });
+  });
+
+  describe('#allowOutsideRoot', () => {
+    // [helper name, argument index of the options object, mem-fs argument index of the forwarded options]
+    const optionsArgument: Array<[name: string, position: number, destPosition: number]> = [
+      ['copyTemplate', 2, 2],
+      ['copyTemplateAsync', 2, 2],
+      ['copyDestination', 2, 2],
+      ['moveDestination', 2, 2],
+      ['writeDestination', 2, 2],
+      ['writeDestinationJSON', 4, 4],
+      ['deleteDestination', 1, 1],
+      ['renderTemplate', 3, 3],
+      ['renderTemplateAsync', 3, 3],
+    ];
+
+    for (const [name, position, destPosition] of optionsArgument) {
+      it(`${name} passes allowOutsideRoot to path methods and strips it from fs options`, async () => {
+        const op = testResults.find(result => result.name === name)!;
+        // A plain object in writeDestinationJSON's replacer position selects its options form, so pass a null replacer.
+        const args: unknown[] = name === 'writeDestinationJSON' ? ['from', 'to', null, 2] : ['from', 'to', {}, {}];
+        args[position] = { allowOutsideRoot: true, foo: 'bar' };
+        await (base[op.name] as any)(...args);
+
+        for (const pathMethod of new Set([op.first, op.second].filter(Boolean))) {
+          const handler = base[pathMethod!] as ReturnType<typeof vi.fn>;
+          const pathCalls = handler.mock.calls.filter(call => call.length > 0);
+          expect(pathCalls.length).toBeGreaterThan(0);
+          for (const call of pathCalls) {
+            expect(call.at(-1)).toEqual({ allowOutsideRoot: true });
+          }
+        }
+
+        const [call] = (base.fs[op.dest] as ReturnType<typeof vi.fn>).mock.calls;
+        expect(call[destPosition]).not.toHaveProperty('allowOutsideRoot');
+        expect(call[destPosition].foo).toBe('bar');
+      });
+    }
+
+    for (const name of ['readTemplate', 'readDestination'] as const) {
+      it(`${name} passes allowOutsideRoot to the path method and strips it from read options`, () => {
+        const op = testResults.find(result => result.name === name)!;
+        base[name]('file', { allowOutsideRoot: true, defaults: 'x' });
+        const [pathCall] = (base[op.first!] as ReturnType<typeof vi.fn>).mock.calls;
+        expect(pathCall).toEqual(['file', { allowOutsideRoot: true }]);
+        const [call] = (base.fs.read as ReturnType<typeof vi.fn>).mock.calls;
+        expect(call[1]).toEqual({ defaults: 'x' });
+      });
+    }
+
+    it('readDestinationJSON passes allowOutsideRoot to destinationPath', () => {
+      base.fs.readJSON = vi.fn();
+      base.readDestinationJSON('file', undefined, { allowOutsideRoot: true });
+      const [pathCall] = (base.destinationPath as ReturnType<typeof vi.fn>).mock.calls;
+      expect(pathCall).toEqual(['file', { allowOutsideRoot: true }]);
+    });
+
+    it('existsDestination passes allowOutsideRoot to destinationPath', () => {
+      base.existsDestination('file', { allowOutsideRoot: true });
+      const [pathCall] = (base.destinationPath as ReturnType<typeof vi.fn>).mock.calls;
+      expect(pathCall).toEqual(['file', { allowOutsideRoot: true }]);
+    });
+
+    it('writeDestinationJSON accepts replacer and space inside options', () => {
+      const replacer = ['a'];
+      base.writeDestinationJSON('file', { a: 1 }, { replacer, space: 4, allowOutsideRoot: true, metadata: { foo: 'bar' } });
+      const [pathCall] = (base.destinationPath as ReturnType<typeof vi.fn>).mock.calls;
+      expect(pathCall).toEqual(['file', { allowOutsideRoot: true }]);
+      const [call] = (base.fs.writeJSON as ReturnType<typeof vi.fn>).mock.calls;
+      expect(call.slice(1)).toEqual([{ a: 1 }, replacer, 4, { metadata: { foo: 'bar' } }]);
+    });
+
+    it('writeDestinationJSON keeps null, array and function replacers positional', () => {
+      const fn = (_key: string, value: unknown) => value;
+      for (const replacer of [null, ['a'], fn]) {
+        base.writeDestinationJSON('file', { a: 1 }, replacer as any, 2, { allowOutsideRoot: true });
+        const call = (base.fs.writeJSON as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+        expect(call.slice(2)).toEqual([replacer, 2, {}]);
+      }
+    });
+
+    it('writeDestination keeps the deprecated stat argument untouched', () => {
+      const stat = { isFile: () => true };
+      base.writeDestination('file', 'content', stat as any);
+      const [call] = (base.fs.write as ReturnType<typeof vi.fn>).mock.calls;
+      expect(call[2]).toBe(stat);
+    });
+
+    it('renderTemplates forwards allowOutsideRoot from template copyOptions', () => {
+      base.renderTemplates([{ source: 'from', destination: 'to', copyOptions: { allowOutsideRoot: true } }], {});
+      const templateCalls = (base.templatePath as ReturnType<typeof vi.fn>).mock.calls.filter(call => call.length > 0);
+      expect(templateCalls).toEqual([['from', { allowOutsideRoot: true }]]);
+      const [call] = (base.fs.copyTpl as ReturnType<typeof vi.fn>).mock.calls;
+      expect(call[3]).not.toHaveProperty('allowOutsideRoot');
     });
   });
 

--- a/test/generators.test.ts
+++ b/test/generators.test.ts
@@ -119,6 +119,18 @@ describe('Generators module', () => {
       expect(global).toBe(customStorage.path);
       expect(customStorage.name).toBeUndefined();
     });
+
+    it('throws with path outside the destination root', () => {
+      const outside = path.join(env.cwd, '..', '.yo-rc-outside.json');
+      expect(() => generator.createStorage(outside)).toThrow(/outside the destination root/);
+    });
+
+    it('with path outside the destination root and allowOutsideRoot option', () => {
+      const outside = path.join(env.cwd, '..', '.yo-rc-outside.json');
+      const customStorage = generator.createStorage(outside, { name: '*', allowOutsideRoot: true });
+      expect(customStorage.path).toBe(outside);
+      expect(customStorage.name).toBe('*');
+    });
   });
 
   describe('#getContextData', () => {


### PR DESCRIPTION
…e their root

`templatePath()` and `destinationPath()` used to return any absolute path as is and joined relative paths without checking where they ended up, so a generator could read or write anywhere on disk through the fs helpers.

Both now throw when the resulting path is not the root itself or a descendant of it. That covers absolute paths outside the root as well as `..` traversals. Absolute paths inside the root are still accepted, so passing an already-resolved path back in keeps working.

Opt out with the `allowTemplatesOutsideRoot` / `allowDestinationOutsideRoot` generator features, or per call with `{ allowOutsideRoot: true }`: as a trailing options object on `templatePath()`/`destinationPath()`, or inside the options object of `createStorage()` and every fs helper, which forward it to the path methods and strip it before calling mem-fs-editor. `readTemplate`/`readDestination` take it alongside `raw`/`defaults`, and `readDestinationJSON`/`existsDestination`, which had no options object, take a trailing `PathOptions` argument. The global storage at the home dir passes it explicitly.

`writeDestinationJSON` also gains a `(filepath, contents, options)` overload with `replacer` and `space` inside the options object. A replacer is a function, an array or null, so a plain object in that position is unambiguous. The positional form is kept.

Helper signatures are spelled out as explicit tuples instead of `Parameters<MemFsEditor[...]>` since the mem-fs types had no room for the extra key; the read helpers now expose the `raw: true` Buffer overloads too.

BREAKING CHANGE: `templatePath()` and `destinationPath()` throw when the resolved path is outside the source/destination root.

<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/.github/blob/master/.github/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [ ] Enhancement
- [ ] Other, please explain:

## What changes did you make?

<!-- Give an overview -->

## Is there anything you'd like reviewers to focus on?

<!-- Just in case -->