### PR TITLE
feat: create destination root on demand at createSimpleGit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import process from 'node:process';
 import { CheckRepoActions, CleanOptions, type SimpleGit, type SimpleGitOptions, simpleGit } from 'simple-git';
 import { BaseGenerator } from './generator.js';
 import type { BaseFeatures, BaseOptions } from './types.js';
+import { existsSync, mkdirSync } from 'node:fs';
 
 export type * from './types.js';
 export type * from './questions.js';
@@ -41,6 +42,11 @@ export default class Generator<
   }
 
   createSimpleGit(options?: Partial<SimpleGitOptions>): SimpleGitWithConstants {
+    const baseDir = this.destinationPath();
+    if (!existsSync(baseDir)) {
+      // simple-git requires an existing directory.
+      mkdirSync(baseDir, { recursive: true });
+    }
     const git = simpleGit({ baseDir: this.destinationPath(), ...options }).env({
       HOME: process.env.HOME,
       PATH: process.env.PATH,

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -1166,6 +1166,22 @@ describe('Base', () => {
     });
   });
 
+  describe('#createSimpleGit()', () => {
+    it('creates the destination root when it does not exist, simple-git requires an existing directory', async () => {
+      const destinationRoot = path.resolve('destination', 'not-created');
+      dummy.destinationRoot(destinationRoot);
+      expect(fs.existsSync(destinationRoot)).toBeFalsy();
+
+      const git = dummy.createSimpleGit();
+
+      expect(fs.existsSync(destinationRoot)).toBeTruthy();
+      expect(await git.checkIsRepo(git.CheckRepoActions.IS_REPO_ROOT)).toBe(false);
+
+      await git.init();
+      expect(fs.existsSync(path.join(destinationRoot, '.git'))).toBeTruthy();
+    });
+  });
+
   describe('#destinationPath()', () => {
     const outsidePath = path.resolve('/outside/bar.js');
 


### PR DESCRIPTION
simple-git requires an existing baseDir. Since the destination root is no longer created eagerly, create it when a SimpleGit instance is requested.

<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/.github/blob/master/.github/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [ ] Enhancement
- [ ] Other, please explain:

## What changes did you make?

<!-- Give an overview -->

## Is there anything you'd like reviewers to focus on?

<!-- Just in case -->