### PR TITLE
feat: add allowPackageTemplates feature

### DIFF
--- a/src/actions/fs.ts
+++ b/src/actions/fs.ts
@@ -20,7 +20,7 @@ type ReadOptions = { raw?: boolean; defaults?: string | Buffer | null };
 
 export type Template<G, C extends 'copyTplAsync' | 'copyTpl', D extends NonNullable<Parameters<MemFsEditor[C]>[2]>> = {
   /**
-   * Template file, relative to templatePath(), or absolute inside the source root (outside when the `allowTemplatesOutsideRoot` feature is enabled).
+   * Template file, relative to templatePath(), or absolute inside the source root (outside when the `allowTemplatesOutsideRoot` feature is enabled, inside the generator package when the `allowPackageTemplates` feature is enabled).
    */
   source: string;
   /**
@@ -351,7 +351,7 @@ export class FsMixin {
   /**
    * Copy a template from templates folder to the destination.
    *
-   * @param source - template file, relative to templatePath(), or absolute inside the source root (outside when the `allowTemplatesOutsideRoot` feature is enabled).
+   * @param source - template file, relative to templatePath(), or absolute inside the source root (outside when the `allowTemplatesOutsideRoot` feature is enabled, inside the generator package when the `allowPackageTemplates` feature is enabled).
    * @param destination - destination, relative to destinationPath(), or absolute inside the destination root (outside when the `allowDestinationOutsideRoot` feature is enabled).
    * @param templateData - ejs data
    * @param templateOptions - ejs options
@@ -404,7 +404,7 @@ export class FsMixin {
   /**
    * Copy a template from templates folder to the destination.
    *
-   * @param source - template file, relative to templatePath(), or absolute inside the source root (outside when the `allowTemplatesOutsideRoot` feature is enabled).
+   * @param source - template file, relative to templatePath(), or absolute inside the source root (outside when the `allowTemplatesOutsideRoot` feature is enabled, inside the generator package when the `allowPackageTemplates` feature is enabled).
    * @param destination - destination, relative to destinationPath(), or absolute inside the destination root (outside when the `allowDestinationOutsideRoot` feature is enabled).
    * @param templateData - ejs data
    * @param templateOptions - ejs options
@@ -481,7 +481,7 @@ export class FsMixin {
   /**
    * Copy templates from templates folder to the destination.
    *
-   * @param templates - template file, relative to templatePath(), or absolute inside the source root (outside when the `allowTemplatesOutsideRoot` feature is enabled).
+   * @param templates - template file, relative to templatePath(), or absolute inside the source root (outside when the `allowTemplatesOutsideRoot` feature is enabled, inside the generator package when the `allowPackageTemplates` feature is enabled).
    * @param templateData - ejs data
    */
   async renderTemplatesAsync<const D extends NonNullable<Parameters<MemFsEditor['copyTplAsync']>[2]>>(

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -900,8 +900,22 @@ export class BaseGenerator<
   }
 
   /**
+   * Whether `filepath` is inside the generator package, when the `allowPackageTemplates` feature is enabled.
+   * The package root is the `packagePath` from the meta provided by the environment, when not provided the feature is ignored.
+   */
+  #isPackageTemplate(filepath: string): boolean {
+    if (!this.#features.allowPackageTemplates) {
+      return false;
+    }
+
+    const packageRoot = this._meta?.packagePath;
+    return packageRoot ? isInsideRoot(packageRoot, filepath) : false;
+  }
+
+  /**
    * Join a path to the source root.
-   * Throws if the resulting path is not inside the source root, unless the `allowTemplatesOutsideRoot` feature or the `allowOutsideRoot` option is enabled.
+   * Throws if the resulting path is not inside the source root, unless the `allowTemplatesOutsideRoot` feature,
+   * the `allowPackageTemplates` feature (for paths inside the generator package) or the `allowOutsideRoot` option is enabled.
    * @param dest - path parts, optionally followed by a `PathOptions` object
    * @return joined path
    */
@@ -911,10 +925,15 @@ export class BaseGenerator<
     const [dest, options] = splitPathArguments(args);
     const root = this.sourceRoot();
     const filepath = joinToRoot(root, dest);
-    if (!(options?.allowOutsideRoot ?? this.#features.allowTemplatesOutsideRoot) && !isInsideRoot(root, filepath)) {
-      throw new Error(
-        `templatePath() resolved '${filepath}' outside the source root '${root}'. Pass a path inside the root, enable the 'allowTemplatesOutsideRoot' feature, or pass the '{ allowOutsideRoot: true }' option.`,
-      );
+    if (!isInsideRoot(root, filepath)) {
+      // The per call option takes precedence over the features.
+      const allowed =
+        options?.allowOutsideRoot ?? (this.#features.allowTemplatesOutsideRoot || this.#isPackageTemplate(filepath));
+      if (!allowed) {
+        throw new Error(
+          `templatePath() resolved '${filepath}' outside the source root '${root}'. Pass a path inside the root, enable the 'allowTemplatesOutsideRoot' feature, enable the 'allowPackageTemplates' feature for a path inside the generator package, or pass the '{ allowOutsideRoot: true }' option.`,
+        );
+      }
     }
 
     return filepath;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -120,6 +120,15 @@ export type BaseFeatures = Merge<
     allowTemplatesOutsideRoot?: boolean;
 
     /**
+     * Allow `templatePath()` to resolve paths anywhere inside the generator package.
+     * The package root is the `packagePath` from the generator meta provided by the environment.
+     * When the meta has no `packagePath`, the feature is ignored and only the source root is allowed.
+     * Useful to share templates between generators of the same package.
+     * Can be overridden per call using the `allowOutsideRoot` option.
+     */
+    allowPackageTemplates?: boolean;
+
+    /**
      * Allow `destinationPath()` to resolve paths outside the destination root.
      * By default a resulting path that is not inside the destination root throws.
      * Can be overridden per call using the `allowOutsideRoot` option.
@@ -131,7 +140,7 @@ export type BaseFeatures = Merge<
 
 export type PathOptions = {
   /**
-   * Allow the resulting path to be outside the root, overriding the `allowTemplatesOutsideRoot`/`allowDestinationOutsideRoot` feature.
+   * Allow the resulting path to be outside the root, overriding the `allowTemplatesOutsideRoot`/`allowPackageTemplates`/`allowDestinationOutsideRoot` feature.
    */
   allowOutsideRoot?: boolean;
 };

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -1154,6 +1154,51 @@ describe('Base', () => {
       const generator = new Dummy([], { env, resolved: 'foo/bar' }, { allowTemplatesOutsideRoot: true });
       expect(() => generator.templatePath(outsidePath, { allowOutsideRoot: false })).toThrow(/outside the source root/);
     });
+
+    describe('with allowPackageTemplates feature', () => {
+      const packagePath = path.resolve('/package');
+      const resolved = path.join(packagePath, 'generators', 'app', 'index.js');
+      const sharedTemplate = path.join(packagePath, 'generators', 'shared', 'templates', 'bar.js');
+      let generator: Base;
+
+      beforeEach(() => {
+        generator = new Dummy(
+          [],
+          { env, resolved, _meta: { namespace: 'dummy', packagePath } },
+          { allowPackageTemplates: true },
+        );
+      });
+
+      it('allows path inside the package taken from meta packagePath', () => {
+        expect(generator.templatePath(sharedTemplate)).toBe(sharedTemplate);
+        expect(generator.templatePath('..', '..', 'shared', 'templates', 'bar.js')).toBe(sharedTemplate);
+        expect(generator.templatePath(packagePath)).toBe(packagePath);
+      });
+
+      it('throws on path outside the package', () => {
+        expect(() => generator.templatePath(outsidePath)).toThrow(/allowPackageTemplates/);
+        expect(() => generator.templatePath(`${packagePath}-sibling/bar.js`)).toThrow(/outside the source root/);
+        expect(() => generator.templatePath(path.join(packagePath, '..', 'bar.js'))).toThrow(/outside the source root/);
+      });
+
+      it('is not applied without the feature', () => {
+        const generator = new Dummy([], { env, resolved, _meta: { namespace: 'dummy', packagePath } });
+        expect(() => generator.templatePath(sharedTemplate)).toThrow(/outside the source root/);
+      });
+
+      it('option takes precedence over feature', () => {
+        expect(() => generator.templatePath(sharedTemplate, { allowOutsideRoot: false })).toThrow(
+          /outside the source root/,
+        );
+        expect(generator.templatePath(outsidePath, { allowOutsideRoot: true })).toBe(outsidePath);
+      });
+
+      it('is ignored when meta has no packagePath', () => {
+        const generator = new Dummy([], { env, resolved }, { allowPackageTemplates: true });
+        expect(() => generator.templatePath(sharedTemplate)).toThrow(/outside the source root/);
+        expect(generator.templatePath('bar.js')).toBe(path.join(generator.sourceRoot(), 'bar.js'));
+      });
+    });
   });
 
   describe('#destinationRoot()', () => {
@@ -1210,6 +1255,15 @@ describe('Base', () => {
 
     it('ignores allowTemplatesOutsideRoot feature', () => {
       const generator = new Dummy([], { env, resolved: 'foo/bar' }, { allowTemplatesOutsideRoot: true });
+      expect(() => generator.destinationPath(outsidePath)).toThrow(/outside the destination root/);
+    });
+
+    it('ignores allowPackageTemplates feature', () => {
+      const generator = new Dummy(
+        [],
+        { env, resolved: 'foo/bar', _meta: { namespace: 'dummy', packagePath: path.resolve('/') } },
+        { allowPackageTemplates: true },
+      );
       expect(() => generator.destinationPath(outsidePath)).toThrow(/outside the destination root/);
     });
 


### PR DESCRIPTION
Allow templatePath() to resolve paths anywhere inside the generator package, so templates can be shared between generators of the same package. The package root is meta.packagePath provided by the environment; when it is not provided the feature is ignored.

<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/.github/blob/master/.github/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [ ] Enhancement
- [ ] Other, please explain:

## What changes did you make?

<!-- Give an overview -->

## Is there anything you'd like reviewers to focus on?

<!-- Just in case -->